### PR TITLE
ALFMOB-48: Fixed chip layout for sizing swatch

### DIFF
--- a/Alfie/Alfie/Views/ProductDetails/ProductDetailsView.swift
+++ b/Alfie/Alfie/Views/ProductDetails/ProductDetailsView.swift
@@ -431,7 +431,7 @@ extension ProductDetailsView {
                     if !canShowSizePickers {
                         SizingSelectorComponentView(
                             configuration: viewModel.sizingSelectionConfiguration,
-                            layoutConfiguration: .init(arrangement: .grid(columns: 3, columnWidth: 60))
+                            layoutConfiguration: .init(arrangement: .grid(columns: 3))
                         )
                     }
                 } else {

--- a/Alfie/Packages/Models/Sources/UI/SizeSelection/SizingSwatch.swift
+++ b/Alfie/Packages/Models/Sources/UI/SizeSelection/SizingSwatch.swift
@@ -26,7 +26,7 @@ public struct SwatchLayoutConfiguration {
     public enum Arrangement {
         case horizontal(itemSpacing: CGFloat, scrollable: Bool = true)
         case chips(itemHorizontalSpacing: CGFloat, itemVerticalSpacing: CGFloat)
-        case grid(columns: Int, columnWidth: CGFloat)
+        case grid(columns: Int, columnWidth: CGFloat = .zero)
     }
 
     public init(arrangement: Arrangement, hideSelectionTitle: Bool = false, hideOnSingleColor: Bool = true) {

--- a/Alfie/Packages/StyleGuide/Sources/Demo/SizingBanner/SizingBannerDemoView.swift
+++ b/Alfie/Packages/StyleGuide/Sources/Demo/SizingBanner/SizingBannerDemoView.swift
@@ -43,7 +43,7 @@ struct SizingBannerDemoView: View {
                 section(title: "Sizing Swatches - Grid") {
                     SizingSelectorComponentView(
                         configuration: .init(selectedTitle: Self.selectedTitle, items: Self.items),
-                        layoutConfiguration: .init(arrangement: .grid(columns: 4, columnWidth: 50))
+                        layoutConfiguration: .init(arrangement: .grid(columns: 4))
                     )
                 }
 

--- a/Alfie/Packages/StyleGuide/Sources/Theme/Components/SizingBanner/SizingSelectorComponentView.swift
+++ b/Alfie/Packages/StyleGuide/Sources/Theme/Components/SizingBanner/SizingSelectorComponentView.swift
@@ -17,13 +17,13 @@ public struct SizingSelectorComponentView: View {
             horizontalSwatches(itemSpacing: itemSpacing, scrollable: scrollable)
         case .chips(let horizontalSpacing, let verticalSpacing):
             chipsSwatches(horizontalSpacing: horizontalSpacing, verticalSpacing: verticalSpacing)
-        case .grid(let columns, let columnWidth):
-            gridSwatches(columns: columns, columnWidth: columnWidth)
+        case .grid(let columns, _):
+            gridSwatches(columns: columns)
         }
         // swiftlint:enable vertical_whitespace_between_cases
     }
 
-    private func gridSwatches(columns: Int, columnWidth: CGFloat) -> some View {
+    private func gridSwatches(columns: Int) -> some View {
         LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: columns)) {
             swatches()
         }
@@ -75,7 +75,7 @@ public struct SizingSelectorComponentView: View {
                 .init(id: "8", name: "XXXXL", state: .available),
             ]
         ),
-        layoutConfiguration: .init(arrangement: .grid(columns: 4, columnWidth: 50))
+        layoutConfiguration: .init(arrangement: .grid(columns: 4))
     )
 }
 

--- a/Alfie/Packages/StyleGuide/Sources/Theme/Layouts/ChipsStackLayout.swift
+++ b/Alfie/Packages/StyleGuide/Sources/Theme/Layouts/ChipsStackLayout.swift
@@ -10,7 +10,7 @@ public struct ChipsStackLayout: Layout {
     }
 
     public func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
-        let sizes = subviews.map { $0.sizeThatFits(proposal) }
+        let sizes = subviews.map { $0.sizeThatFits(.unspecified) }
         let maxViewHeight = sizes.map { $0.height }.max() ?? 0
         var currentRowWidth: CGFloat = 0
         var totalHeight: CGFloat = maxViewHeight
@@ -29,7 +29,7 @@ public struct ChipsStackLayout: Layout {
     }
 
     public func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
-        let sizes = subviews.map { $0.sizeThatFits(proposal) }
+        let sizes = subviews.map { $0.sizeThatFits(.unspecified) }
         let maxViewHeight = sizes.map { $0.height }.max() ?? 0
         var point = CGPoint(x: bounds.minX, y: bounds.minY)
         for index in subviews.indices {


### PR DESCRIPTION
- Fixed chip layout for sizing swatch in Catalogue App
- Fixed right padding of content

Before             |  After
:-------------------------:|:-------------------------:
![Simulator Screenshot - iPhone 16 Pro - 2024-12-03 at 16 30 03](https://github.com/user-attachments/assets/e0bb90cd-b1fc-44f0-bec2-e66fa3ee066e) | ![Simulator Screenshot - iPhone 16 Pro - 2024-12-03 at 16 35 03](https://github.com/user-attachments/assets/ec2ad9da-e397-4b23-9182-ec4ae338506d)