### PR TITLE
ALFMOB-62: Fix swipe to back not working

### DIFF
--- a/Alfie/Alfie/Helpers/ToolbarItemProvider.swift
+++ b/Alfie/Alfie/Helpers/ToolbarItemProvider.swift
@@ -55,11 +55,7 @@ enum ToolbarItemProvider {
                 .productDetails,
                 .productListing,
                 .categoryList:
-                if coordinator.canPop() {
-                    backButton(with: coordinator)
-                } else {
                     EmptyView()
-                }
 
             default:
                 EmptyView()

--- a/Alfie/AlfieKit/Sources/StyleGuide/Components/Toolbar/ThemedToolbarModifier.swift
+++ b/Alfie/AlfieKit/Sources/StyleGuide/Components/Toolbar/ThemedToolbarModifier.swift
@@ -11,10 +11,11 @@ public struct ThemedToolbarModifier: ViewModifier {
 
     @ViewBuilder
     public func body(content: Content) -> some View {
+        if showDivider {
+            Divider()
+                .background(Colors.primary.mono200)
+        }
         content
-            .navigationBarBackButtonHidden()
             .navigationBarTitleDisplayMode(.inline)
-            .toolbarBackground(Colors.primary.white)
-            .toolbarBackground(showDivider ? .visible : .hidden, for: .navigationBar)
     }
 }

--- a/Alfie/AlfieKit/Sources/StyleGuide/Demo/Helper/ContainerDemoViewModifier.swift
+++ b/Alfie/AlfieKit/Sources/StyleGuide/Demo/Helper/ContainerDemoViewModifier.swift
@@ -25,14 +25,10 @@ public struct ContainerDemoViewModifier: ViewModifier {
             }
         }
         .toolbar {
-            ToolbarItem(placement: .topBarLeading) {
-                ThemedToolbarButton(icon: .arrowLeft) { dismiss() }
-            }
             ToolbarItem(placement: .principal) {
                 ThemedToolbarTitle(style: .logo)
             }
         }
         .modifier(ThemedToolbarModifier())
-        .navigationBarBackButtonHidden()
     }
 }

--- a/Alfie/AlfieKit/Sources/StyleGuide/Demo/Snackbars/SnackbarDemoView.swift
+++ b/Alfie/AlfieKit/Sources/StyleGuide/Demo/Snackbars/SnackbarDemoView.swift
@@ -57,15 +57,11 @@ struct SnackbarDemoView: View {
         }
         .snackbarView(configuration: $snackbarConfig)
         .toolbar {
-            ToolbarItem(placement: .topBarLeading) {
-                ThemedToolbarButton(icon: .arrowLeft) { dismiss() }
-            }
             ToolbarItem(placement: .principal) {
                 ThemedToolbarTitle(style: .logo)
             }
         }
         .modifier(ThemedToolbarModifier())
-        .navigationBarBackButtonHidden()
     }
 
     private func button(label: String) -> some View {

--- a/Alfie/AlfieKit/Sources/StyleGuide/Demo/Toolbar/ToolbarDemoView.swift
+++ b/Alfie/AlfieKit/Sources/StyleGuide/Demo/Toolbar/ToolbarDemoView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct ToolbarDemoView: View {
-    private enum ToolbarButtonMode: String, CaseIterable {
+    private enum ToolbarRightButtonMode: String, CaseIterable {
         case singleIcon = "Single Icon"
         case singleText = "Single Text"
         case multiIcon = "Multiple Icon"
@@ -22,14 +22,28 @@ struct ToolbarDemoView: View {
         }
     }
 
+    private enum ToolbarLeftButtonMode: String, CaseIterable {
+        case singleIcon = "Single Icon"
+        case multiIcon = "Multiple Icon"
+        case multiMixed = "Multiple Mixed"
+
+        var isIcon: Bool {
+            [.singleIcon, .multiIcon, .multiMixed].contains(self)
+        }
+
+        var isMulti: Bool {
+            [.multiIcon, .multiMixed].contains(self)
+        }
+    }
+
     // TODO: replace usage of dismiss with a coordinator, here and in other demo views (not possible for now, as we have a crash due to a missing env obj, to be fixed later)
     @Environment(\.dismiss) private var dismiss
     @State private var showLogo = true
     @State private var alwaysShowDivider = true
     @State private var darkMode = false
     @State private var leftAlign = false
-    @State private var rightMode: ToolbarButtonMode? = .multiIcon
-    @State private var leftMode: ToolbarButtonMode? = .singleIcon
+    @State private var rightMode: ToolbarRightButtonMode? = .multiIcon
+    @State private var leftMode: ToolbarLeftButtonMode? = .singleIcon
 
     var body: some View {
         ScrollView {
@@ -55,9 +69,9 @@ struct ToolbarDemoView: View {
                 DemoHelper.demoSectionHeader(title: "Controls (Left / Right)")
                     .padding(.top, Spacing.space250)
 
-                HStack(spacing: Spacing.space0) {
+                HStack(alignment: .top, spacing: Spacing.space0) {
                     RadioButtonList(
-                        values: ToolbarButtonMode.allCases,
+                        values: ToolbarLeftButtonMode.allCases,
                         disabledValues: .constant([]),
                         selectedValue: $leftMode,
                         verticalSpacing: Spacing.space300
@@ -66,7 +80,7 @@ struct ToolbarDemoView: View {
                     Spacer()
 
                     RadioButtonList(
-                        values: ToolbarButtonMode.allCases,
+                        values: ToolbarRightButtonMode.allCases,
                         disabledValues: .constant([]),
                         selectedValue: $rightMode,
                         verticalSpacing: Spacing.space300
@@ -82,6 +96,7 @@ struct ToolbarDemoView: View {
             principalToolbarContent
             trailingToolbarContent
         }
+        .modifier(ThemedToolbarModifier(showDivider: alwaysShowDivider))
         .onChange(of: leftAlign) { newValue in
             if newValue {
                 showLogo = false
@@ -92,10 +107,6 @@ struct ToolbarDemoView: View {
                 leftAlign = false
             }
         }
-        .toolbarBackground(darkMode ? Colors.primary.mono900 : Colors.primary.white)
-        .toolbarBackground(alwaysShowDivider ? .visible : .automatic, for: .navigationBar)
-        .navigationBarTitleDisplayMode(.inline)
-        .navigationBarBackButtonHidden()
         .onChange(of: darkMode) { newValue in
             if newValue {
                 alwaysShowDivider = true
@@ -111,20 +122,12 @@ struct ToolbarDemoView: View {
                     tint: !darkMode ? Colors.primary.mono900 : Colors.primary.white
                 )
             } else {
-                if let mode = leftMode, mode != .hidden {
+                if let mode = leftMode, mode.isMulti {
                     ThemedToolbarButton(
-                        icon: mode.isIcon ? .arrowLeft : nil,
-                        text: mode.isText ? "Back" : nil,
+                        icon: mode.isIcon && mode != .multiMixed ? .store : nil,
+                        text: mode == .multiMixed ? "Shop" : nil,
                         tint: darkMode ? Colors.primary.white : Colors.primary.mono900
-                    ) { dismiss() }
-
-                    if mode.isMulti {
-                        ThemedToolbarButton(
-                            icon: mode.isIcon && mode != .multiMixed ? .store : nil,
-                            text: mode.isText || mode == .multiMixed ? "Shop" : nil,
-                            tint: darkMode ? Colors.primary.white : Colors.primary.mono900
-                        ) {}
-                    }
+                    ) {}
                 }
             }
         }

--- a/Alfie/AlfieKit/Sources/StyleGuide/Theme/Icons/IconRepresentable.swift
+++ b/Alfie/AlfieKit/Sources/StyleGuide/Theme/Icons/IconRepresentable.swift
@@ -17,7 +17,7 @@ public extension RawRepresentable where Self: IconRepresentable, RawValue == Str
     }
 
     var uiImage: UIImage {
-        .init(named: rawValue, in: bundle, with: nil) ?? UIImage()
+        .init(systemName: rawValue) ?? UIImage()
     }
 
     var bundle: Bundle {

--- a/Alfie/AlfieKit/Sources/StyleGuide/Theme/ThemeProvider.swift
+++ b/Alfie/AlfieKit/Sources/StyleGuide/Theme/ThemeProvider.swift
@@ -46,6 +46,24 @@ public class ThemeProvider: ThemeProviderProtocol {
         let appearance = UINavigationBarAppearance()
         appearance.configureWithTransparentBackground()
         appearance.backgroundColor = backgroundColor
+
+        let backButtonAppearance = UIBarButtonItemAppearance(style: .plain)
+        backButtonAppearance.focused.titleTextAttributes = [.foregroundColor: UIColor.clear]
+        backButtonAppearance.disabled.titleTextAttributes = [.foregroundColor: UIColor.clear]
+        backButtonAppearance.highlighted.titleTextAttributes = [.foregroundColor: UIColor.clear]
+        backButtonAppearance.normal.titleTextAttributes = [.foregroundColor: UIColor.clear]
+
+        backButtonAppearance.focused.titlePositionAdjustment = .init(horizontal: -44, vertical: 0)
+        backButtonAppearance.disabled.titlePositionAdjustment = .init(horizontal: -44, vertical: 0)
+        backButtonAppearance.highlighted.titlePositionAdjustment = .init(horizontal: -44, vertical: 0)
+        backButtonAppearance.normal.titlePositionAdjustment = .init(horizontal: -44, vertical: 0)
+
+        appearance.backButtonAppearance = backButtonAppearance
+        appearance.setBackIndicatorImage(
+            Icon.arrowLeft.uiImage,
+            transitionMaskImage: Icon.arrowLeft.uiImage
+        )
+
         UINavigationBar.appearance().standardAppearance = appearance
         UINavigationBar.appearance().compactAppearance = appearance
         UINavigationBar.appearance().scrollEdgeAppearance = appearance


### PR DESCRIPTION
### Ticket
https://mindera.atlassian.net/browse/ALFMOB-62

### Description
The swipe-to-back gesture was not functioning because hiding the native navigation back button also disables the `interactivePopGestureRecognizer`. To resolve this, we updated the approach to modify the appearance of the navigation back button instead of hiding it.