### PR TITLE
ALFMOB-82: Search button appearing twice on PLP

### DIFF
--- a/Alfie/AlfieKit/Sources/StyleGuide/Components/Toolbar/ThemedToolbarModifier.swift
+++ b/Alfie/AlfieKit/Sources/StyleGuide/Components/Toolbar/ThemedToolbarModifier.swift
@@ -11,11 +11,13 @@ public struct ThemedToolbarModifier: ViewModifier {
 
     @ViewBuilder
     public func body(content: Content) -> some View {
-        if showDivider {
-            Divider()
-                .background(Colors.primary.mono200)
+        VStack {
+            if showDivider {
+                Divider()
+                    .background(Colors.primary.mono200)
+            }
+            content
+                .navigationBarTitleDisplayMode(.inline)
         }
-        content
-            .navigationBarTitleDisplayMode(.inline)
     }
 }


### PR DESCRIPTION
### Ticket
https://mindera.atlassian.net/browse/ALFMOB-82

### Description

**Root Cause:** The duplication of the search button was caused by a mismatch in the SwiftUI view hierarchy when the Divider was conditionally added outside of the content. This caused SwiftUI to incorrectly process the UINavigationBar context, resulting in the button being added twice.

**Fix:** Wrapping the Divider and content inside a VStack ensures that SwiftUI treats them as a single cohesive unit. This prevents the navigation system from incorrectly refreshing or duplicating the toolbar items.

**Regression from:** https://mindera.atlassian.net/browse/ALFMOB-62