### PR TITLE
ALFMOB-89: Error screen header not fixed to the top

### DIFF
--- a/Alfie/Alfie/Views/ErrorView/ErrorButtonConfiguration.swift
+++ b/Alfie/Alfie/Views/ErrorView/ErrorButtonConfiguration.swift
@@ -1,7 +1,0 @@
-import Foundation
-
-struct ErrorButtonConfiguration: Identifiable {
-    let id: String = UUID().uuidString
-    let text: String
-    let action: () -> Void
-}

--- a/Alfie/Alfie/Views/ErrorView/ErrorButtonConfiguration.swift
+++ b/Alfie/Alfie/Views/ErrorView/ErrorButtonConfiguration.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct ErrorButtonConfiguration: Identifiable {
+    let id: String = UUID().uuidString
+    let text: String
+    let action: () -> Void
+}

--- a/Alfie/Alfie/Views/ErrorView/ErrorView.swift
+++ b/Alfie/Alfie/Views/ErrorView/ErrorView.swift
@@ -20,7 +20,7 @@ struct ErrorView: View {
     private let titleColor: Color
     private let message: AttributedString?
     private let messageColor: Color
-    private let buttons: [ThemedButton]
+    private let buttonsConfiguration: [ErrorButtonConfiguration]
 
     // MARK: Lifecycle
 
@@ -33,7 +33,7 @@ struct ErrorView: View {
         titleColor: Color = Colors.primary.black,
         message: AttributedString? = nil,
         messageColor: Color = Colors.primary.black,
-        buttons: [ThemedButton] = []
+        buttonsConfiguration: [ErrorButtonConfiguration] = []
     ) {
         self.spacing = spacing
         self.icon = icon
@@ -43,7 +43,7 @@ struct ErrorView: View {
         self.titleColor = titleColor
         self.message = message
         self.messageColor = messageColor
-        self.buttons = buttons
+        self.buttonsConfiguration = buttonsConfiguration
     }
 
     init(
@@ -55,7 +55,7 @@ struct ErrorView: View {
         titleColor: Color = Colors.primary.black,
         message: String? = nil,
         messageColor: Color = Colors.primary.black,
-        buttons: [ThemedButton] = []
+        buttonsConfiguration: [ErrorButtonConfiguration] = []
     ) {
         self.init(
             spacing: spacing,
@@ -66,7 +66,7 @@ struct ErrorView: View {
             titleColor: titleColor,
             message: message.flatMap(ThemeProvider.shared.font.small.normal),
             messageColor: messageColor,
-            buttons: buttons
+            buttonsConfiguration: buttonsConfiguration
         )
     }
 
@@ -94,8 +94,12 @@ struct ErrorView: View {
             }
 
             VStack(spacing: Spacing.space100) {
-                ForEach(buttons.indices, id: \.self) { index in
-                    buttons[index]
+                ForEach(buttonsConfiguration) { configuration in
+                    ThemedButton(
+                        text: configuration.text,
+                        isFullWidth: true,
+                        action: configuration.action
+                    )
                 }
             }
 

--- a/Alfie/Alfie/Views/ErrorView/ErrorView.swift
+++ b/Alfie/Alfie/Views/ErrorView/ErrorView.swift
@@ -1,0 +1,105 @@
+import StyleGuide
+import SwiftUI
+
+// MARK: - Constants
+
+private enum Constants {
+    static let iconSize: CGFloat = 48
+}
+
+// MARK: - ErrorView
+
+struct ErrorView: View {
+    // MARK: Properties
+
+    private let spacing: CGFloat
+    private let icon: Image?
+    private let iconColor: Color
+    private let iconSize: CGFloat
+    private let title: AttributedString?
+    private let titleColor: Color
+    private let message: AttributedString?
+    private let messageColor: Color
+    private let buttons: [ThemedButton]
+
+    // MARK: Lifecycle
+
+    init(
+        spacing: CGFloat = Spacing.space200,
+        icon: Image? = Icon.warning.image,
+        iconColor: Color = Colors.primary.black,
+        iconSize: CGFloat = Constants.iconSize,
+        title: AttributedString? = nil,
+        titleColor: Color = Colors.primary.black,
+        message: AttributedString? = nil,
+        messageColor: Color = Colors.primary.black,
+        buttons: [ThemedButton] = []
+    ) {
+        self.spacing = spacing
+        self.icon = icon
+        self.iconColor = iconColor
+        self.iconSize = iconSize
+        self.title = title
+        self.titleColor = titleColor
+        self.message = message
+        self.messageColor = messageColor
+        self.buttons = buttons
+    }
+
+    init(
+        spacing: CGFloat = Spacing.space200,
+        icon: Image? = Icon.warning.image,
+        iconColor: Color = Colors.primary.black,
+        iconSize: CGFloat = Constants.iconSize,
+        title: String? = nil,
+        titleColor: Color = Colors.primary.black,
+        message: String? = nil,
+        messageColor: Color = Colors.primary.black,
+        buttons: [ThemedButton] = []
+    ) {
+        self.init(
+            spacing: spacing,
+            icon: icon,
+            iconColor: iconColor,
+            iconSize: iconSize,
+            title: title.flatMap(ThemeProvider.shared.font.paragraph.bold),
+            titleColor: titleColor,
+            message: message.flatMap(ThemeProvider.shared.font.small.normal),
+            messageColor: messageColor,
+            buttons: buttons
+        )
+    }
+
+    var body: some View {
+        VStack(spacing: spacing) {
+            Spacer()
+
+            if let icon {
+                icon
+                    .renderingMode(.template)
+                    .resizable()
+                    .foregroundStyle(iconColor)
+                    .scaledToFit()
+                    .frame(width: iconSize, height: iconSize)
+            }
+
+            if let title {
+                Text.build(title)
+                    .foregroundStyle(Colors.primary.black)
+            }
+
+            if let message {
+                Text.build(message)
+                    .foregroundStyle(Colors.primary.black)
+            }
+
+            VStack(spacing: Spacing.space100) {
+                ForEach(buttons.indices, id: \.self) { index in
+                    buttons[index]
+                }
+            }
+
+            Spacer()
+        }
+    }
+}

--- a/Alfie/Alfie/Views/ErrorView/ErrorView.swift
+++ b/Alfie/Alfie/Views/ErrorView/ErrorView.swift
@@ -10,6 +10,17 @@ private enum Constants {
 // MARK: - ErrorView
 
 struct ErrorView: View {
+    // MARK: Inner types
+
+    struct ButtonConfiguration: Identifiable {
+        let cta: String
+        let action: () -> Void
+
+        var id: String {
+            cta
+        }
+    }
+
     // MARK: Properties
 
     private let spacing: CGFloat
@@ -20,7 +31,7 @@ struct ErrorView: View {
     private let titleColor: Color
     private let message: AttributedString?
     private let messageColor: Color
-    private let buttonsConfiguration: [ErrorButtonConfiguration]
+    private let buttons: [ButtonConfiguration]
 
     // MARK: Lifecycle
 
@@ -33,7 +44,7 @@ struct ErrorView: View {
         titleColor: Color = Colors.primary.black,
         message: AttributedString? = nil,
         messageColor: Color = Colors.primary.black,
-        buttonsConfiguration: [ErrorButtonConfiguration] = []
+        buttons: [ButtonConfiguration] = []
     ) {
         self.spacing = spacing
         self.icon = icon
@@ -43,7 +54,7 @@ struct ErrorView: View {
         self.titleColor = titleColor
         self.message = message
         self.messageColor = messageColor
-        self.buttonsConfiguration = buttonsConfiguration
+        self.buttons = buttons
     }
 
     init(
@@ -55,7 +66,7 @@ struct ErrorView: View {
         titleColor: Color = Colors.primary.black,
         message: String? = nil,
         messageColor: Color = Colors.primary.black,
-        buttonsConfiguration: [ErrorButtonConfiguration] = []
+        buttons: [ButtonConfiguration] = []
     ) {
         self.init(
             spacing: spacing,
@@ -66,7 +77,7 @@ struct ErrorView: View {
             titleColor: titleColor,
             message: message.flatMap(ThemeProvider.shared.font.small.normal),
             messageColor: messageColor,
-            buttonsConfiguration: buttonsConfiguration
+            buttons: buttons
         )
     }
 
@@ -94,12 +105,8 @@ struct ErrorView: View {
             }
 
             VStack(spacing: Spacing.space100) {
-                ForEach(buttonsConfiguration) { configuration in
-                    ThemedButton(
-                        text: configuration.text,
-                        isFullWidth: true,
-                        action: configuration.action
-                    )
+                ForEach(buttons) {
+                    ThemedButton(text: $0.cta, isFullWidth: true, action: $0.action)
                 }
             }
 

--- a/Alfie/Alfie/Views/ProductDetails/ProductDetailsView.swift
+++ b/Alfie/Alfie/Views/ProductDetails/ProductDetailsView.swift
@@ -521,8 +521,8 @@ extension ProductDetailsView {
             title: theme.font.header.h2(L10n.Pdp.ErrorView.title),
             message: theme.font.paragraph.normal(errorMessage),
             messageColor: Colors.primary.mono600,
-            buttonsConfiguration: [
-                .init(text: L10n.Pdp.ErrorView.GoBack.Button.cta) {
+            buttons: [
+                .init(cta: L10n.Pdp.ErrorView.GoBack.Button.cta) {
                     coordinator.didTapBackButton()
                 },
             ]

--- a/Alfie/Alfie/Views/ProductDetails/ProductDetailsView.swift
+++ b/Alfie/Alfie/Views/ProductDetails/ProductDetailsView.swift
@@ -521,8 +521,8 @@ extension ProductDetailsView {
             title: theme.font.header.h2(L10n.Pdp.ErrorView.title),
             message: theme.font.paragraph.normal(errorMessage),
             messageColor: Colors.primary.mono600,
-            buttons: [
-                ThemedButton(text: L10n.Pdp.ErrorView.GoBack.Button.cta, isFullWidth: true) {
+            buttonsConfiguration: [
+                .init(text: L10n.Pdp.ErrorView.GoBack.Button.cta) {
                     coordinator.didTapBackButton()
                 },
             ]

--- a/Alfie/Alfie/Views/ProductDetails/ProductDetailsView.swift
+++ b/Alfie/Alfie/Views/ProductDetails/ProductDetailsView.swift
@@ -515,19 +515,18 @@ extension ProductDetailsView {
     }
 
     @ViewBuilder private var errorView: some View {
-        // TODO: properly implement the error views in a future ticket (with the refresh CTA and proper labels)
-        VStack(spacing: Spacing.space500) {
-            Circle()
-                .fill(Colors.primary.mono200)
-                .frame(width: Constants.errorViewCircleSize, height: Constants.errorViewCircleSize)
-            Text.build(theme.font.header.h2(L10n.Pdp.ErrorView.title))
-                .foregroundStyle(Colors.primary.black)
-            Text.build(theme.font.paragraph.normal(errorMessage))
-                .foregroundStyle(Colors.primary.mono600)
-            ThemedButton(text: L10n.Pdp.ErrorView.GoBack.Button.cta, isFullWidth: true) {
-                coordinator.didTapBackButton()
-            }
-        }
+        ErrorView(
+            spacing: Spacing.space500,
+            iconSize: Constants.errorViewIconSize,
+            title: theme.font.header.h2(L10n.Pdp.ErrorView.title),
+            message: theme.font.paragraph.normal(errorMessage),
+            messageColor: Colors.primary.mono600,
+            buttons: [
+                ThemedButton(text: L10n.Pdp.ErrorView.GoBack.Button.cta, isFullWidth: true) {
+                    coordinator.didTapBackButton()
+                },
+            ]
+        )
     }
 
     private func complementaryInfoCell(type: ProductDetailsComplementaryInfoType, showTopDivider: Bool) -> some View {
@@ -574,7 +573,7 @@ private enum Constants {
     static let chevronSize: CGFloat = 16
     static let sheetCloseIconSize: CGFloat = 16
     static let complementaryInfoCellMinHeight: CGFloat = 72
-    static let errorViewCircleSize: CGFloat = 210
+    static let errorViewIconSize: CGFloat = 210
     static let colorChevronSize: CGFloat = 16
 }
 

--- a/Alfie/Alfie/Views/ProductListing/ProductListingView.swift
+++ b/Alfie/Alfie/Views/ProductListing/ProductListingView.swift
@@ -9,7 +9,6 @@ import Mocks
 // MARK: - Constants
 
 private enum Constants {
-    static let iconSize: CGFloat = 48
     /// Layout Grid Struct Items Per Row
     static let iPhoneGridRows = 2
     static let iPhoneListRows = 1
@@ -149,19 +148,10 @@ struct ProductListingView<ViewModel: ProductListingViewModelProtocol>: View {
     }
 
     private var errorView: some View {
-        // TODO: Remove this after implementing reusable error views
-        VStack(spacing: Spacing.space200) {
-            Icon.warning.image
-                .renderingMode(.template)
-                .resizable()
-                .foregroundStyle(Colors.primary.black)
-                .scaledToFit()
-                .frame(width: Constants.iconSize, height: Constants.iconSize)
-            Text.build(theme.font.paragraph.bold(L10n.Plp.ErrorView.title))
-                .foregroundStyle(Colors.primary.black)
-            Text.build(theme.font.small.normal(L10n.Plp.ErrorView.message))
-                .foregroundStyle(Colors.primary.black)
-        }
+        ErrorView(
+            title: L10n.Plp.ErrorView.title,
+            message: L10n.Plp.ErrorView.message
+        )
     }
 }
 

--- a/Alfie/Alfie/Views/ShopView/Brands/BrandsView.swift
+++ b/Alfie/Alfie/Views/ShopView/Brands/BrandsView.swift
@@ -164,42 +164,18 @@ struct BrandsView<ViewModel: BrandsViewModelProtocol>: View {
     // MARK: Error View
 
     private var errorView: some View {
-        // TODO: Remove this after implementing reusable error views
-        VStack(spacing: Spacing.space200) {
-            Spacer()
-            imageForIcon(Icon.warning)
-            Text.build(theme.font.paragraph.bold(L10n.Shop.Brands.ErrorView.title))
-                .foregroundStyle(Colors.primary.black)
-            Text.build(theme.font.small.normal(L10n.Shop.Brands.ErrorView.message))
-                .foregroundStyle(Colors.primary.black)
-            Spacer()
-        }
-        .frame(maxWidth: .infinity)
-        .contentShape(Rectangle())
+        ErrorView(
+            title: L10n.Shop.Brands.ErrorView.title,
+            message: L10n.Shop.Brands.ErrorView.message
+        )
     }
 
     private var emptySearchResults: some View {
-        // TODO: Remove this after implementing reusable error views
-        VStack(spacing: Spacing.space200) {
-            Spacer()
-            imageForIcon(Icon.search)
-            HStack(spacing: Spacing.space050) {
-                Text.build(theme.font.small.normal(L10n.Shop.Brands.SearchBar.noResultsMessage))
-                    .foregroundStyle(Colors.primary.black)
-                Text.build(theme.font.small.bold("'\(viewModel.searchText)'"))
-                    .foregroundStyle(Colors.primary.black)
-            }
-            Spacer()
-        }
-    }
-
-    private func imageForIcon(_ icon: Icon) -> some View {
-        icon.image
-            .renderingMode(.template)
-            .resizable()
-            .foregroundStyle(Colors.primary.black)
-            .scaledToFit()
-            .frame(width: Constants.iconSize, height: Constants.iconSize)
+        ErrorView(
+            icon: Icon.search.image,
+            message: theme.font.small.normal(L10n.Shop.Brands.SearchBar.noResultsMessage) +
+                theme.font.small.bold(" '\(viewModel.searchText)'")
+        )
     }
 }
 
@@ -349,7 +325,6 @@ private struct VisiblePreferenceKey: PreferenceKey {
 // MARK: - Constants
 
 private enum Constants {
-    static let iconSize: CGFloat = 48
     static let headerViewHeight: CGFloat = 40
     static let brandViewHeight: CGFloat = 56
     static let sectionIndexSize: CGFloat = 16

--- a/Alfie/Alfie/Views/ShopView/Categories/CategoriesView.swift
+++ b/Alfie/Alfie/Views/ShopView/Categories/CategoriesView.swift
@@ -98,21 +98,10 @@ struct CategoriesView<ViewModel: CategoriesViewModelProtocol>: View {
     }
 
     private var errorView: some View {
-        // TODO: Remove this after implementing reusable error views
-        VStack(spacing: Spacing.space200) {
-            Spacer()
-            Icon.warning.image
-                .renderingMode(.template)
-                .resizable()
-                .foregroundStyle(Colors.primary.black)
-                .scaledToFit()
-                .frame(width: Constants.iconSize, height: Constants.iconSize)
-            Text.build(theme.font.paragraph.bold(L10n.Shop.Categories.ErrorView.title))
-                .foregroundStyle(Colors.primary.black)
-            Text.build(theme.font.small.normal(L10n.Shop.Categories.ErrorView.message))
-                .foregroundStyle(Colors.primary.black)
-            Spacer()
-        }
+        ErrorView(
+            title: L10n.Shop.Categories.ErrorView.title,
+            message: L10n.Shop.Categories.ErrorView.message
+        )
     }
 
     private func categoriesListItem(for text: String, isShimmering: Bool, foregroundColor: Color) -> some View {
@@ -144,7 +133,6 @@ private enum AccessibilityId {
 private enum Constants {
     static let segmentedControlHeight: CGFloat = 46
     static let chevronSize: CGFloat = 16
-    static let iconSize: CGFloat = 48
     static let categoryViewHeight: CGFloat = 56
 }
 

--- a/Alfie/Alfie/Views/WebView/WebView.swift
+++ b/Alfie/Alfie/Views/WebView/WebView.swift
@@ -44,23 +44,23 @@ struct WebView<ViewModel: WebViewModelProtocol>: View {
     }
 
     private var errorView: some View {
-        VStack(spacing: Spacing.space500) {
-            Circle()
-                .fill(Colors.primary.mono200)
-                .frame(width: Constants.errorViewCircleSize, height: Constants.errorViewCircleSize)
-            Text.build(theme.font.header.h2(L10n.WebView.ErrorView.title))
-                .foregroundStyle(Colors.primary.black)
-            Text.build(theme.font.paragraph.normal(L10n.WebView.ErrorView.Generic.message))
-                .foregroundStyle(Colors.primary.mono600)
-            ThemedButton(text: L10n.WebView.ErrorView.Button.cta, isFullWidth: true) {
-                viewModel.tryAgain()
-            }
-        }
+        ErrorView(
+            spacing: Spacing.space500,
+            iconSize: Constants.errorViewIconSize,
+            title: theme.font.header.h2(L10n.WebView.ErrorView.title),
+            message: theme.font.paragraph.normal(L10n.WebView.ErrorView.Generic.message),
+            messageColor: Colors.primary.mono600,
+            buttons: [
+                ThemedButton(text: L10n.WebView.ErrorView.Button.cta, isFullWidth: true) {
+                    viewModel.tryAgain()
+                },
+            ]
+        )
     }
 }
 
 private enum Constants {
-    static let errorViewCircleSize: CGFloat = 210
+    static let errorViewIconSize: CGFloat = 210
 }
 
 class CustomWebViewNoAccessory: WKWebView {

--- a/Alfie/Alfie/Views/WebView/WebView.swift
+++ b/Alfie/Alfie/Views/WebView/WebView.swift
@@ -50,8 +50,8 @@ struct WebView<ViewModel: WebViewModelProtocol>: View {
             title: theme.font.header.h2(L10n.WebView.ErrorView.title),
             message: theme.font.paragraph.normal(L10n.WebView.ErrorView.Generic.message),
             messageColor: Colors.primary.mono600,
-            buttonsConfiguration: [
-                .init(text: L10n.WebView.ErrorView.Button.cta) {
+            buttons: [
+                .init(cta: L10n.WebView.ErrorView.Button.cta) {
                     viewModel.tryAgain()
                 },
             ]

--- a/Alfie/Alfie/Views/WebView/WebView.swift
+++ b/Alfie/Alfie/Views/WebView/WebView.swift
@@ -50,8 +50,8 @@ struct WebView<ViewModel: WebViewModelProtocol>: View {
             title: theme.font.header.h2(L10n.WebView.ErrorView.title),
             message: theme.font.paragraph.normal(L10n.WebView.ErrorView.Generic.message),
             messageColor: Colors.primary.mono600,
-            buttons: [
-                ThemedButton(text: L10n.WebView.ErrorView.Button.cta, isFullWidth: true) {
+            buttonsConfiguration: [
+                .init(text: L10n.WebView.ErrorView.Button.cta) {
                     viewModel.tryAgain()
                 },
             ]

--- a/Alfie/AlfieKit/Sources/StyleGuide/Components/Toolbar/ThemedToolbarModifier.swift
+++ b/Alfie/AlfieKit/Sources/StyleGuide/Components/Toolbar/ThemedToolbarModifier.swift
@@ -19,5 +19,6 @@ public struct ThemedToolbarModifier: ViewModifier {
             content
                 .navigationBarTitleDisplayMode(.inline)
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
     }
 }


### PR DESCRIPTION
### Ticket

https://mindera.atlassian.net/browse/ALFMOB-89

### Description

The divider in the toolbar was not fixed to the top. To resolve this, we now use `frame` and `alignment` to anchor it at the top. However, this also causes views that should be centered within the remaining space to align at the top. To address this, some error views required a `Spacer` at the top and bottom. As part of this fix, a generic `ErrorView was created for use in all error scenarios.

### Evidences
<img src="https://github.com/user-attachments/assets/a967c72d-d4a6-4c04-90f5-91e131d30e2b" width="200">
<img src="https://github.com/user-attachments/assets/18df6b40-cc39-4e8a-a05b-eca39b1de2eb" width="200">
<img src="https://github.com/user-attachments/assets/d5d67e55-b660-4e0e-9dca-f9a3557bd5d7" width="200">
<img src="https://github.com/user-attachments/assets/cda35564-c6f0-4fb0-8fd6-59853cbbdf0a" width="200">
<img src="https://github.com/user-attachments/assets/f92ea335-b98d-49cd-8c2d-ad1210dc08fe" width="200">
<img src="https://github.com/user-attachments/assets/7279df87-9425-4146-9e7a-294e8210e53f" width="200">
<img src="https://github.com/user-attachments/assets/60f078b3-5c6a-4570-ac96-779dbe99fed9" width="200">
