### PR TITLE
ALFMOB-141: Optimize Unit Test Execution Time

### DIFF
--- a/Alfie/Alfie.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Alfie/Alfie.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -46,6 +46,15 @@
       }
     },
     {
+      "identity" : "combine-schedulers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/combine-schedulers",
+      "state" : {
+        "revision" : "5928286acce13def418ec36d05a001a9641086f2",
+        "version" : "1.0.3"
+      }
+    },
+    {
       "identity" : "easystash",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/onmyway133/EasyStash.git",
@@ -181,6 +190,15 @@
       }
     },
     {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "82a4ae7170d98d8538ec77238b7eb8e7199ef2e8",
+        "version" : "1.3.1"
+      }
+    },
+    {
       "identity" : "swift-protobuf",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
@@ -214,6 +232,15 @@
       "state" : {
         "revision" : "4659156ae082430840be407e25af56cfa9d64ab3",
         "version" : "6.6.4-mindera"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "39de59b2d47f7ef3ca88a039dff3084688fe27f4",
+        "version" : "1.5.2"
       }
     }
   ],

--- a/Alfie/Alfie/Alfie.xctestplan
+++ b/Alfie/Alfie/Alfie.xctestplan
@@ -34,9 +34,6 @@
       }
     },
     {
-      "skippedTests" : [
-        "AppStartupServiceTests\/test_currentScreen_is_eventually_landing()"
-      ],
       "target" : {
         "containerPath" : "container:Alfie.xcodeproj",
         "identifier" : "BE8B02332B616979007AE489",

--- a/Alfie/Alfie/Navigation/DeepLinking/DeepLinkHandler.swift
+++ b/Alfie/Alfie/Navigation/DeepLinking/DeepLinkHandler.swift
@@ -1,4 +1,5 @@
 import Combine
+import CombineSchedulers
 import Foundation
 import Models
 import Navigation
@@ -10,12 +11,16 @@ final class DeepLinkHandler: DeepLinkHandlerProtocol {
     private var subscriptions = Set<AnyCancellable>()
     private var isReadyToHandleLinks = false
 
-    init(configurationService: ConfigurationServiceProtocol, coordinator: TabCoordinatorProtocol) {
+    init(
+        configurationService: ConfigurationServiceProtocol,
+        coordinator: TabCoordinatorProtocol,
+        scheduler: AnySchedulerOf<DispatchQueue> = .main
+    ) {
         self.configurationService = configurationService
         self.coordinator = coordinator
 
         self.coordinator.navigationAvailability
-            .receive(on: DispatchQueue.main)
+            .receive(on: scheduler)
             .sink { [weak self] isReadyToHandleLinks in
                 self?.isReadyToHandleLinks = isReadyToHandleLinks
                 if isReadyToHandleLinks {

--- a/Alfie/Alfie/Service/AppStartupService.swift
+++ b/Alfie/Alfie/Service/AppStartupService.swift
@@ -39,7 +39,7 @@ final class AppStartupService: AppStartupServiceProtocol {
         self.configurationService = configurationService
         setupSubscriptions()
         WebViewPreload.preloadWebView()
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + configurationService.startupCompletionDelay) {
             self.isLoading.send(false)
         }
     }

--- a/Alfie/Alfie/Service/AppStartupService.swift
+++ b/Alfie/Alfie/Service/AppStartupService.swift
@@ -35,11 +35,11 @@ final class AppStartupService: AppStartupServiceProtocol {
         appStartupScreenCondition.first { $0.value }?.key ?? .error
     }
 
-    init(configurationService: ConfigurationServiceProtocol) {
+    init(configurationService: ConfigurationServiceProtocol, startupCompletionDelay: CGFloat = 2) {
         self.configurationService = configurationService
         setupSubscriptions()
         WebViewPreload.preloadWebView()
-        DispatchQueue.main.asyncAfter(deadline: .now() + configurationService.startupCompletionDelay) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + startupCompletionDelay) {
             self.isLoading.send(false)
         }
     }

--- a/Alfie/Alfie/Views/ProductDetails/ProductDetailsDependencyContainer.swift
+++ b/Alfie/Alfie/Views/ProductDetails/ProductDetailsDependencyContainer.swift
@@ -1,7 +1,9 @@
+import CombineSchedulers
 import Foundation
 import Models
 
 final class ProductDetailsDependencyContainer {
+    let scheduler: AnySchedulerOf<DispatchQueue>
     let productService: ProductServiceProtocol
     let webUrlProvider: WebURLProviderProtocol
     let bagService: BagServiceProtocol
@@ -10,6 +12,7 @@ final class ProductDetailsDependencyContainer {
     let analytics: AlfieAnalyticsTracker
 
     init(
+        scheduler: AnySchedulerOf<DispatchQueue> = .main,
         productService: ProductServiceProtocol,
         webUrlProvider: WebURLProviderProtocol,
         bagService: BagServiceProtocol,
@@ -17,6 +20,7 @@ final class ProductDetailsDependencyContainer {
         configurationService: ConfigurationServiceProtocol,
         analytics: AlfieAnalyticsTracker
     ) {
+        self.scheduler = scheduler
         self.productService = productService
         self.webUrlProvider = webUrlProvider
         self.bagService = bagService

--- a/Alfie/Alfie/Views/ProductDetails/ProductDetailsViewModel.swift
+++ b/Alfie/Alfie/Views/ProductDetails/ProductDetailsViewModel.swift
@@ -229,7 +229,7 @@ final class ProductDetailsViewModel: ProductDetailsViewModelProtocol {
             selectedItem: selectedSwatch
         )
         colorSelectionSubscription = colorSelectionConfiguration.$selectedItem
-            .receive(on: DispatchQueue.main)
+            .receive(on: dependencies.scheduler)
             .dropFirst()
             .sink { [weak self] colorSwatch in
                 guard let self, let colorSwatch else {
@@ -286,7 +286,7 @@ final class ProductDetailsViewModel: ProductDetailsViewModelProtocol {
             selectedItem: selectedSwatch
         )
         sizingSelectionSubscription = sizingSelectionConfiguration.$selectedItem
-            .receive(on: DispatchQueue.main)
+            .receive(on: dependencies.scheduler)
             .dropFirst()
             .sink { [weak self] sizingSwatch in
                 guard let self, let sizingSwatch else {

--- a/Alfie/Alfie/Views/SearchView/SearchDependencyContainer.swift
+++ b/Alfie/Alfie/Views/SearchView/SearchDependencyContainer.swift
@@ -1,20 +1,21 @@
+import CombineSchedulers
 import Core
 import Foundation
 import Models
 
 final class SearchDependencyContainer {
-    let executionQueue: DispatchQueue
+    let scheduler: AnySchedulerOf<DispatchQueue>
     let recentsService: RecentsServiceProtocol?
     let searchService: SearchServiceProtocol
     let analytics: AlfieAnalyticsTracker
 
     init(
-        executionQueue: DispatchQueue = DispatchQueue.main,
+        scheduler: AnySchedulerOf<DispatchQueue> = .main,
         recentsService: RecentsServiceProtocol?,
         searchService: SearchServiceProtocol,
         analytics: AlfieAnalyticsTracker
     ) {
-        self.executionQueue = executionQueue
+        self.scheduler = scheduler
         self.recentsService = recentsService
         self.searchService = searchService
         self.analytics = analytics

--- a/Alfie/Alfie/Views/SearchView/SearchViewModel.swift
+++ b/Alfie/Alfie/Views/SearchView/SearchViewModel.swift
@@ -76,7 +76,7 @@ extension SearchViewModel {
                     self?.state = .loading
                 }
             })
-            .debounce(for: .seconds(Constants.searchDebounceIntervalInSeconds), scheduler: dependencies.executionQueue)
+            .debounce(for: dependencies.searchService.suggestionsDebounceInterval, scheduler: dependencies.scheduler)
             .sink { [weak self] searchText in
                 self?.handleChange(on: searchText)
             }

--- a/Alfie/Alfie/Views/WishlistView/WishlistView.swift
+++ b/Alfie/Alfie/Views/WishlistView/WishlistView.swift
@@ -58,7 +58,6 @@ private extension WishlistView {
 
 #if DEBUG
 #Preview {
-    let serviceProvider = MockServiceProvider()
     WishlistView(
         viewModel: WishlistViewModel(
             dependencies: WishlistDependencyContainer(

--- a/Alfie/AlfieKit/Package.swift
+++ b/Alfie/AlfieKit/Package.swift
@@ -89,11 +89,11 @@ let package = Package(
                 .product(name: "AlicerceLogging", package: "Alicerce"),
                 .product(name: "Apollo", package: "apollo-ios"),
                 .product(name: "BrazeKit", package: "braze-swift-sdk"),
-                .product(name: "FirebaseRemoteConfig",package: "firebase-ios-sdk"),
-                .product(name: "FirebaseCrashlytics", package: "firebase-ios-sdk"),
-                .product(name: "FirebaseAnalytics", package: "firebase-ios-sdk"),
-                .product(name: "NukeUI", package: "nuke"),
                 .product(name: "CombineSchedulers", package: "combine-schedulers"),
+                .product(name: "FirebaseAnalytics", package: "firebase-ios-sdk"),
+                .product(name: "FirebaseCrashlytics", package: "firebase-ios-sdk"),
+                .product(name: "FirebaseRemoteConfig",package: "firebase-ios-sdk"),
+                .product(name: "NukeUI", package: "nuke"),
             ]
         ),
         

--- a/Alfie/AlfieKit/Package.swift
+++ b/Alfie/AlfieKit/Package.swift
@@ -52,8 +52,8 @@ let package = Package(
         .package(url: "https://github.com/firebase/firebase-ios-sdk.git", exact: "10.22.1"),
         .package(url: "https://github.com/kean/Nuke.git", exact: "12.4.0"),
         .package(url: "https://github.com/Mindera/Alicerce.git", exact: "0.18.0"),
-        .package(url: "https://github.com/onmyway133/EasyStash.git", exact: "1.1.9")
-        
+        .package(url: "https://github.com/onmyway133/EasyStash.git", exact: "1.1.9"),
+        .package(url: "https://github.com/pointfreeco/combine-schedulers", exact: "1.0.3"),
     ],
     targets: [
         .target(
@@ -92,7 +92,8 @@ let package = Package(
                 .product(name: "FirebaseRemoteConfig",package: "firebase-ios-sdk"),
                 .product(name: "FirebaseCrashlytics", package: "firebase-ios-sdk"),
                 .product(name: "FirebaseAnalytics", package: "firebase-ios-sdk"),
-                .product(name: "NukeUI", package: "nuke")
+                .product(name: "NukeUI", package: "nuke"),
+                .product(name: "CombineSchedulers", package: "combine-schedulers"),
             ]
         ),
         
@@ -136,7 +137,10 @@ let package = Package(
         ),
         
         .target(
-            name: "TestUtils"
+            name: "TestUtils",
+            dependencies: [
+                .product(name: "CombineSchedulers", package: "combine-schedulers"),
+            ]
         ),
         
         .testTarget(

--- a/Alfie/AlfieKit/Sources/Core/Services/API/Search/SearchService.swift
+++ b/Alfie/AlfieKit/Sources/Core/Services/API/Search/SearchService.swift
@@ -7,9 +7,12 @@ public final class SearchService: SearchServiceProtocol {
 
     // MARK: - Public
 
-    public init(bffClient: BFFClientServiceProtocol) {
+    public init(
+        bffClient: BFFClientServiceProtocol,
+        suggestionsDebounceInterval: DispatchQueue.SchedulerTimeType.Stride = .seconds(0.5)
+    ) {
         self.bffClient = bffClient
-        self.suggestionsDebounceInterval = .seconds(0.5)
+        self.suggestionsDebounceInterval = suggestionsDebounceInterval
     }
 
     public func getSuggestion(term: String) async throws -> SearchSuggestion {

--- a/Alfie/AlfieKit/Sources/Core/Services/API/Search/SearchService.swift
+++ b/Alfie/AlfieKit/Sources/Core/Services/API/Search/SearchService.swift
@@ -3,11 +3,13 @@ import Models
 
 public final class SearchService: SearchServiceProtocol {
     private let bffClient: BFFClientServiceProtocol
+    public let suggestionsDebounceInterval: DispatchQueue.SchedulerTimeType.Stride
 
     // MARK: - Public
 
     public init(bffClient: BFFClientServiceProtocol) {
         self.bffClient = bffClient
+        self.suggestionsDebounceInterval = .seconds(0.5)
     }
 
     public func getSuggestion(term: String) async throws -> SearchSuggestion {

--- a/Alfie/AlfieKit/Sources/Core/Services/Configuration/ConfigurationService.swift
+++ b/Alfie/AlfieKit/Sources/Core/Services/Configuration/ConfigurationService.swift
@@ -72,6 +72,8 @@ public final class ConfigurationService: ConfigurationServiceProtocol {
 
     // MARK: - ConfigurationServiceProtocol
 
+    public var startupCompletionDelay: CGFloat { 2 }
+
     public func isFeatureEnabled(_ key: ConfigurationKey) -> Bool {
         // Custom keys must always be read in real time, others are fetched from the publisher
         if case .custom = key {

--- a/Alfie/AlfieKit/Sources/Core/Services/Configuration/ConfigurationService.swift
+++ b/Alfie/AlfieKit/Sources/Core/Services/Configuration/ConfigurationService.swift
@@ -72,8 +72,6 @@ public final class ConfigurationService: ConfigurationServiceProtocol {
 
     // MARK: - ConfigurationServiceProtocol
 
-    public var startupCompletionDelay: CGFloat { 2 }
-
     public func isFeatureEnabled(_ key: ConfigurationKey) -> Bool {
         // Custom keys must always be read in real time, others are fetched from the publisher
         if case .custom = key {

--- a/Alfie/AlfieKit/Sources/Mocks/Core/Services/MockConfigurationService.swift
+++ b/Alfie/AlfieKit/Sources/Mocks/Core/Services/MockConfigurationService.swift
@@ -14,8 +14,6 @@ public class MockConfigurationService: ConfigurationServiceProtocol {
     public var forcedProviderBecameAvailableSubject: PassthroughSubject<Void, Never> = .init()
     public private(set) var providerBecameAvailablePublisher: AnyPublisher<Void, Never>
 
-    public var startupCompletionDelay: CGFloat { 0 }
-
     public init(forceAppUpdateInfo: AppUpdateInfo? = nil,
                 softAppUpdateInfo: AppUpdateInfo? = nil) {
         self.forceAppUpdateInfo = forceAppUpdateInfo

--- a/Alfie/AlfieKit/Sources/Mocks/Core/Services/MockConfigurationService.swift
+++ b/Alfie/AlfieKit/Sources/Mocks/Core/Services/MockConfigurationService.swift
@@ -1,4 +1,5 @@
 import Combine
+import Foundation
 import Models
 
 public class MockConfigurationService: ConfigurationServiceProtocol {
@@ -12,6 +13,8 @@ public class MockConfigurationService: ConfigurationServiceProtocol {
 
     public var forcedProviderBecameAvailableSubject: PassthroughSubject<Void, Never> = .init()
     public private(set) var providerBecameAvailablePublisher: AnyPublisher<Void, Never>
+
+    public var startupCompletionDelay: CGFloat { 0 }
 
     public init(forceAppUpdateInfo: AppUpdateInfo? = nil,
                 softAppUpdateInfo: AppUpdateInfo? = nil) {

--- a/Alfie/AlfieKit/Sources/Mocks/Core/Services/MockSearchService.swift
+++ b/Alfie/AlfieKit/Sources/Mocks/Core/Services/MockSearchService.swift
@@ -4,7 +4,7 @@ import Models
 public final class MockSearchService: SearchServiceProtocol {
     public init() { }
 
-    public var suggestionsDebounceInterval: DispatchQueue.SchedulerTimeType.Stride { .seconds(0.5) }
+    public var suggestionsDebounceInterval: DispatchQueue.SchedulerTimeType.Stride = .seconds(0.5)
     public var onGetSuggestionCalled: ((String) throws -> SearchSuggestion)?
     public func getSuggestion(term: String) async throws -> SearchSuggestion {
         guard let suggestion = try onGetSuggestionCalled?(term) else {

--- a/Alfie/AlfieKit/Sources/Mocks/Core/Services/MockSearchService.swift
+++ b/Alfie/AlfieKit/Sources/Mocks/Core/Services/MockSearchService.swift
@@ -4,6 +4,7 @@ import Models
 public final class MockSearchService: SearchServiceProtocol {
     public init() { }
 
+    public var suggestionsDebounceInterval: DispatchQueue.SchedulerTimeType.Stride { .seconds(0.5) }
     public var onGetSuggestionCalled: ((String) throws -> SearchSuggestion)?
     public func getSuggestion(term: String) async throws -> SearchSuggestion {
         guard let suggestion = try onGetSuggestionCalled?(term) else {

--- a/Alfie/AlfieKit/Sources/Models/Services/Configuration/ConfigurationServiceProtocol.swift
+++ b/Alfie/AlfieKit/Sources/Models/Services/Configuration/ConfigurationServiceProtocol.swift
@@ -8,6 +8,7 @@ public protocol ConfigurationServiceProtocol {
     var forceAppUpdateInfo: AppUpdateInfo? { get }
     var isSoftAppUpdateAvailable: Bool { get }
     var softAppUpdateInfo: AppUpdateInfo? { get }
+    var startupCompletionDelay: CGFloat { get }
 
     func isFeatureEnabled(_ key: ConfigurationKey) -> Bool
 }

--- a/Alfie/AlfieKit/Sources/Models/Services/Configuration/ConfigurationServiceProtocol.swift
+++ b/Alfie/AlfieKit/Sources/Models/Services/Configuration/ConfigurationServiceProtocol.swift
@@ -8,7 +8,6 @@ public protocol ConfigurationServiceProtocol {
     var forceAppUpdateInfo: AppUpdateInfo? { get }
     var isSoftAppUpdateAvailable: Bool { get }
     var softAppUpdateInfo: AppUpdateInfo? { get }
-    var startupCompletionDelay: CGFloat { get }
 
     func isFeatureEnabled(_ key: ConfigurationKey) -> Bool
 }

--- a/Alfie/AlfieKit/Sources/Models/Services/Search/SearchServiceProtocol.swift
+++ b/Alfie/AlfieKit/Sources/Models/Services/Search/SearchServiceProtocol.swift
@@ -1,5 +1,7 @@
 import Foundation
 
 public protocol SearchServiceProtocol {
+    var suggestionsDebounceInterval: DispatchQueue.SchedulerTimeType.Stride { get }
+
     func getSuggestion(term: String) async throws -> SearchSuggestion
 }

--- a/Alfie/AlfieKit/Sources/TestUtils/Helpers/TimeInterval+Extension.swift
+++ b/Alfie/AlfieKit/Sources/TestUtils/Helpers/TimeInterval+Extension.swift
@@ -1,0 +1,6 @@
+import XCTest
+
+extension TimeInterval {
+    public static let `default`: TimeInterval = 2.0
+    public static let inverted: TimeInterval = 0.01
+}

--- a/Alfie/AlfieKit/Sources/TestUtils/Helpers/XCTestCase+Combine.swift
+++ b/Alfie/AlfieKit/Sources/TestUtils/Helpers/XCTestCase+Combine.swift
@@ -3,39 +3,10 @@ import CombineSchedulers
 import XCTest
 
 extension XCTestCase {
-//    @discardableResult
-//    public func XCTAssertEmitsValue<P: Publisher>(
-//        from publisher: P,
-//        where predicate: @escaping (P.Output) -> Bool = { _ in true },
-//        afterTrigger eventTrigger: @escaping () -> Void = {},
-//        timeout: TimeInterval = .default
-//    ) -> P.Output? where P.Failure == Never {
-//        var value: P.Output?
-//        let eventTriggered: PassthroughSubject<Void, Never> = .init()
-//        let expectation = expectation(description: #function)
-//        var cancellable: AnyCancellable?
-//
-//        cancellable = publisher
-//            .drop(untilOutputFrom: eventTriggered)
-//            .first(where: predicate)
-//            .sink { capturedValue in
-//                value = capturedValue
-//                expectation.fulfill()
-//            }
-//
-//        eventTriggered.send()
-//        eventTrigger()
-//
-//        wait(for: [expectation], timeout: timeout)
-//        cancellable?.cancel()
-//
-//        return value
-//    }
-
     @discardableResult
-    private func assertEmitsValue<P: Publisher>(
+    public func XCTAssertEmitsValue<P: Publisher>(
         from publisher: P,
-        predicate: @escaping (P.Output) -> Bool,
+        where predicate: @escaping (P.Output) -> Bool = { _ in true },
         afterTrigger eventTrigger: @escaping () -> Void = {},
         timeout: TimeInterval = .default
     ) -> P.Output? where P.Failure == Never {
@@ -61,30 +32,15 @@ extension XCTestCase {
         return value
     }
 
-    @discardableResult
-    public func XCTAssertEmitsValue<P: Publisher>(
-        from publisher: P,
-        where predicate: @escaping (P.Output) -> Bool = { _ in true },
-        afterTrigger eventTrigger: @escaping () -> Void = {},
-        timeout: TimeInterval = .default
-    ) -> P.Output? where P.Failure == Never {
-        assertEmitsValue(
-            from: publisher,
-            predicate: predicate,
-            afterTrigger: eventTrigger,
-            timeout: timeout
-        )
-    }
-
     public func XCTAssertEmitsValueEqualTo<P: Publisher>(
         from publisher: P,
         expectedValue: P.Output,
         afterTrigger eventTrigger: @escaping () -> Void = {},
         timeout: TimeInterval = .default
     ) where P.Failure == Never, P.Output: Equatable {
-        assertEmitsValue(
+        XCTAssertEmitsValue(
             from: publisher,
-            predicate: { $0 == expectedValue },
+            where: { $0 == expectedValue },
             afterTrigger: eventTrigger,
             timeout: timeout
         )
@@ -96,9 +52,9 @@ extension XCTestCase {
         afterTrigger eventTrigger: @escaping () -> Void = {},
         timeout: TimeInterval = .default
     ) where P.Failure == Never, P.Output: Equatable {
-        assertEmitsValue(
+        XCTAssertEmitsValue(
             from: publisher,
-            predicate: { $0 != unexpectedValue },
+            where: { $0 != unexpectedValue },
             afterTrigger: eventTrigger,
             timeout: timeout
         )
@@ -181,8 +137,8 @@ extension XCTestCase {
 
     public func XCTAssertEmitsFailure<P: Publisher>(
         from publisher: P,
-        errorHandler: @escaping (_ error: P.Failure) -> Void,
-        timeout: TimeInterval = .default
+        timeout: TimeInterval = .default,
+        errorHandler: @escaping (_ error: P.Failure) -> Void
     ) {
         let expectation = expectation(description: #function)
         var receivedError: P.Failure?

--- a/Alfie/AlfieKit/Sources/TestUtils/Helpers/XCTestCase+Combine.swift
+++ b/Alfie/AlfieKit/Sources/TestUtils/Helpers/XCTestCase+Combine.swift
@@ -1,245 +1,147 @@
 import Combine
+import CombineSchedulers
 import XCTest
 
 extension XCTestCase {
-    public func waitUntil<T: Equatable>(publisher: AnyPublisher<T, Never>, emitsValue: T, asyncOperation: (() -> Void)? = nil, timeout: TimeInterval = 2.0) {
-        let exp = expectation(description: "publisher emits value")
-        var subscriptions: Set<AnyCancellable> = []
-
-        publisher.sink { value in
-            guard value == emitsValue else {
-                return
-            }
-            exp.fulfill()
-        }
-        .store(in: &subscriptions)
-
-        asyncOperation?()
-
-        waitForExpectations(timeout: timeout, handler: nil)
-    }
-
-    public func waitUntil<T: Equatable>(
-        _ propertyPublisher: Published<T>.Publisher,
-        equals expectedValue: T,
-        timeout: TimeInterval = 2.0,
-        file: StaticString = #file,
-        line: UInt = #line
-    ) {
-        let expectation = expectation(description: "Awaiting value \(expectedValue) to be issued")
+    @discardableResult
+    public func XCTAssertEmitsValue<T, P: Publisher>(
+        from publisher: P,
+        filteringValues: @escaping (T) -> Bool = { _ in true },
+        afterTrigger eventTrigger: () -> Void = {},
+        timeout: TimeInterval = 2.0
+    ) -> T? where P.Output == T, P.Failure == Never {
+        var value: T?
+        let eventTriggered: PassthroughSubject<Void, Never> = .init()
+        let expectation = expectation(description: #function)
         var cancellable: AnyCancellable?
-        cancellable = propertyPublisher
-            .dropFirst()
-            .first { $0 == expectedValue }
-            .sink { value in
-                XCTAssertEqual(value, expectedValue, file: file, line: line)
-                cancellable?.cancel()
+
+        cancellable = publisher
+            .drop(untilOutputFrom: eventTriggered)
+            .first(where: filteringValues)
+            .sink { capturedValue in
+                value = capturedValue
                 expectation.fulfill()
             }
+
+        eventTriggered.send()
+        eventTrigger()
+
         wait(for: [expectation], timeout: timeout)
+        cancellable?.cancel()
+
+        return value
     }
 
     @discardableResult
-    public func captureEvent<P: Publisher>(fromPublisher publisher: P, afterTrigger eventTrigger: () -> Void, timeout: TimeInterval = 2.0) -> P.Output? where P.Failure == Never {
-        var value: P.Output?
+    public func XCTAssertNoEmit<T, P: Publisher>(
+        from publisher: P,
+        afterTrigger eventTrigger: (() -> Void) = {},
+        timeout: TimeInterval
+    ) -> Bool where P.Output == T, P.Failure == Never {
         let eventTriggered: PassthroughSubject<Void, Never> = .init()
-        let exp = expectation(description: #function)
-        var subscriptions: Set<AnyCancellable> = []
+        let expectation = expectation(description: #function)
+        expectation.isInverted = true
+        var cancellable: AnyCancellable?
 
-        publisher
+        cancellable = publisher
             .drop(untilOutputFrom: eventTriggered)
-            .sink { publisherValue in
-                value = publisherValue
-                exp.fulfill()
-            }
-            .store(in: &subscriptions)
+            .sink { _ in expectation.fulfill() }
 
         eventTriggered.send()
         eventTrigger()
 
-        waitForExpectations(timeout: timeout, handler: nil)
-        return value
-    }
-
-    public func assertNoEvent<T>(from publisher: AnyPublisher<T, Never>, afterTrigger eventTrigger: () -> Void, timeout: TimeInterval = 3.0) -> Bool {
-        let eventTriggered: PassthroughSubject<Void, Never> = .init()
-        var subscriptions: Set<AnyCancellable> = []
-        let exp = expectation(description: #function)
-        exp.isInverted = true
-
-        publisher
-            .drop(untilOutputFrom: eventTriggered)
-            .sink { _ in
-                exp.fulfill()
-            }
-            .store(in: &subscriptions)
-
-        eventTriggered.send()
-        eventTrigger()
-
-        let result = XCTWaiter().wait(for: [exp], timeout: timeout)
+        let result = XCTWaiter().wait(for: [expectation], timeout: timeout)
+        cancellable?.cancel()
         return result == .completed
     }
 
-    public func assertNoEvent<T, U>(from publisher: AnyPublisher<T, U>, timeout: TimeInterval = 2.0) -> Bool {
-        var subscriptions: Set<AnyCancellable> = []
-        let exp = expectation(description: #function)
-        exp.isInverted = true
-
-        publisher
-            .sink(receiveCompletion: { _ in }, receiveValue: { _ in
-                exp.fulfill()
-            })
-            .store(in: &subscriptions)
-
-        let result = XCTWaiter().wait(for: [exp], timeout: timeout)
-        return result == .completed
-    }
-
-    public func captureLastEvent<T>(
-        fromPublisher publisher: AnyPublisher<T, Never>,
-        filteringValues: @escaping (T) -> Bool = { _ in true },
-        eventTrigger: () -> Void,
+    public func XCTAssertResult<T, P: Publisher>(
+        from publisher: P,
         timeout: TimeInterval = 2.0
-    ) -> T? {
-        var subscriptions: Set<AnyCancellable> = []
-        var value: T?
-        let exp = expectation(description: "capture first event")
-        // swiftlint:disable:next last_where
-        publisher
-            .filter(filteringValues)
-            .last()
-            .sink { publisherValue in
-                value = publisherValue
-                exp.fulfill()
-            }
-            .store(in: &subscriptions)
+    ) throws -> T where P.Output == T {
+        var result: Result<T, Error>?
+        let expectation = expectation(description: #function)
+        var cancellable: AnyCancellable?
 
-        eventTrigger()
-
-        waitForExpectations(timeout: timeout, handler: nil)
-
-        return value
-    }
-
-    public func array<T>(fromPublisher publisher: AnyPublisher<T, Never>, during duration: TimeInterval = 1.0) -> [T] {
-        var subscriptions: Set<AnyCancellable> = []
-        var values: [T] = []
-
-        publisher.sink { value in
-            values.append(value)
-        }
-        .store(in: &subscriptions)
-
-        sleep(UInt32(duration))
-        return values
-    }
-
-    public func waitResult<T: Publisher>(publisher: T, timeout: TimeInterval = 2.0) throws -> T.Output {
-        var result: Result<T.Output, Error>?
-        let exp = expectation(description: #function)
-
-        let cancellable = publisher
+        cancellable = publisher
             .first()
             .sink(
                 receiveCompletion: { completion in
-                    // swiftlint:disable vertical_whitespace_between_cases
-                    switch completion {
-                    case .failure(let error):
+                    if case .failure(let error) = completion {
                         result = .failure(error)
-                    case .finished:
-                        break
                     }
-                    // swiftlint:enable vertical_whitespace_between_cases
-                    exp.fulfill()
+                    expectation.fulfill()
                 },
                 receiveValue: { value in
                     result = .success(value)
                 }
             )
 
-        waitForExpectations(timeout: timeout)
-        cancellable.cancel()
+        wait(for: [expectation], timeout: timeout)
+        cancellable?.cancel()
 
         let unwrappedResult = try XCTUnwrap(result)
         return try unwrappedResult.get()
     }
 
-    public func assertNoFailure<T, U>(from publisher: AnyPublisher<T, U>, timeout: TimeInterval = 2.0) {
-        let expectation = self.expectation(description: "assert no failure and stream completion")
-        var error: U?
-        var isCompletionCalled = false
-        _ = publisher
-            .sink(receiveCompletion: { completion in
-                isCompletionCalled = true
-                // swiftlint:disable vertical_whitespace_between_cases
-                switch completion {
-                case .finished:
-                    break
-                case .failure(let failure):
-                    error = failure
-                }
-                // swiftlint:enable vertical_whitespace_between_cases
-                expectation.fulfill()
-            }, receiveValue: { _ in
-                // do nothing
-            })
+    public func XCTAssertNoFailure<T, U: Equatable, P: Publisher>(
+        from publisher: P,
+        timeout: TimeInterval = 2.0
+    ) where P.Output == T, P.Failure == U {
+        let expectation = expectation(description: #function)
+        var receivedError: U?
+        var cancellable: AnyCancellable?
 
-        waitForExpectations(timeout: timeout)
-
-        XCTAssertNil(error)
-        XCTAssertTrue(isCompletionCalled)
-    }
-
-    public func assertFailure<T, U: Equatable>(from publisher: AnyPublisher<T, U>, with expectedError: U? = nil, timeout: TimeInterval = 2.0) {
-        let expectation = self.expectation(description: #function)
-        var error: U?
-        var subscriptions: Set<AnyCancellable> = []
-
-        publisher
-            .sink(receiveCompletion: { completion in
-                // swiftlint:disable vertical_whitespace_between_cases
-                switch completion {
-                case .finished:
-                    break
-                case .failure(let failure):
-                    error = failure
-                }
-                // swiftlint:enable vertical_whitespace_between_cases
-                expectation.fulfill()
-            }, receiveValue: { _ in
-                // do nothing
-            })
-            .store(in: &subscriptions)
-
-        waitForExpectations(timeout: 3)
-
-        if expectedError != nil {
-            XCTAssertEqual(expectedError, error)
-        } else {
-            XCTAssertNotNil(error)
-        }
-    }
-
-    public func assertAnyFailure<T, U>(from publisher: AnyPublisher<T, U>, timeout: TimeInterval = 2.0) {
-        let expectation = self.expectation(description: #function)
-        var subscriptions: Set<AnyCancellable> = []
-
-        publisher
-            .sink(receiveCompletion: { completion in
-                // swiftlint:disable vertical_whitespace_between_cases
-                switch completion {
-                case .finished:
-                    break
-                case .failure:
+        cancellable = publisher
+            .sink(
+                receiveCompletion: { completion in
+                    if case .failure(let error) = completion {
+                        receivedError = error
+                    }
                     expectation.fulfill()
-                }
-                // swiftlint:enable vertical_whitespace_between_cases
-            }, receiveValue: { _ in
-                XCTFail("Failure")
-            })
-            .store(in: &subscriptions)
+                },
+                receiveValue: { _ in }
+            )
 
-        waitForExpectations(timeout: 3)
+        wait(for: [expectation], timeout: timeout)
+        cancellable?.cancel()
+
+        XCTAssertNil(receivedError)
+    }
+
+    public func XCTAssertEmitsFailure<T, U: Equatable, P: Publisher>(
+        from publisher: P,
+        expectedError: U? = nil,
+        timeout: TimeInterval = 2.0
+    ) where P.Output == T, P.Failure == U {
+        let expectation = expectation(description: #function)
+        var receivedError: U?
+        var cancellable: AnyCancellable?
+
+        cancellable = publisher
+            .sink(
+                receiveCompletion: { completion in
+                    switch completion {
+                    case .finished:
+                        if expectedError != nil {
+                            XCTFail("Expected failure but received completion")
+                        }
+
+                    case .failure(let error):
+                        receivedError = error
+                    }
+                    expectation.fulfill()
+                },
+                receiveValue: { _ in }
+            )
+
+        wait(for: [expectation], timeout: timeout)
+        cancellable?.cancel()
+
+        if let expectedError {
+            XCTAssertEqual(expectedError, receivedError)
+        } else {
+            XCTAssertNotNil(receivedError)
+        }
     }
 }

--- a/Alfie/AlfieKit/Sources/TestUtils/Helpers/XCTestCase+Extension.swift
+++ b/Alfie/AlfieKit/Sources/TestUtils/Helpers/XCTestCase+Extension.swift
@@ -1,5 +1,6 @@
 import XCTest
 
 extension XCTestCase {
-    public var defaultTimeout: TimeInterval { 2.0 }
+    public var `default`: TimeInterval { 2.0 }
+    public var inverted: TimeInterval { 0.01 }
 }

--- a/Alfie/AlfieKit/Sources/TestUtils/Helpers/XCTestCase+Extension.swift
+++ b/Alfie/AlfieKit/Sources/TestUtils/Helpers/XCTestCase+Extension.swift
@@ -1,6 +1,0 @@
-import XCTest
-
-extension XCTestCase {
-    public var `default`: TimeInterval { 2.0 }
-    public var inverted: TimeInterval { 0.01 }
-}

--- a/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/BrandsServiceTests.swift
+++ b/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/BrandsServiceTests.swift
@@ -29,6 +29,6 @@ final class BrandsServiceTests: XCTestCase {
             _ = try await sut.getBrands()
         }
 
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
     }
 }

--- a/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/BrandsServiceTests.swift
+++ b/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/BrandsServiceTests.swift
@@ -29,6 +29,6 @@ final class BrandsServiceTests: XCTestCase {
             _ = try await sut.getBrands()
         }
 
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: `default`)
     }
 }

--- a/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/BrandsServiceTests.swift
+++ b/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/BrandsServiceTests.swift
@@ -29,6 +29,6 @@ final class BrandsServiceTests: XCTestCase {
             _ = try await sut.getBrands()
         }
 
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: .default)
     }
 }

--- a/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/ConfigurationServiceTests.swift
+++ b/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/ConfigurationServiceTests.swift
@@ -42,7 +42,7 @@ final class ConfigurationServiceTests: XCTestCase {
             })
             .store(in: &subscriptions)
 
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
     }
 
     func test_publishes_updated_feature_availability_after_dependency_updates() {
@@ -71,7 +71,7 @@ final class ConfigurationServiceTests: XCTestCase {
             })
             .store(in: &subscriptions)
 
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
     }
 
     func test_publishes_updated_feature_availability_when_providers_become_ready() {
@@ -104,7 +104,7 @@ final class ConfigurationServiceTests: XCTestCase {
             })
             .store(in: &subscriptions)
 
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
     }
 
     // MARK: - Test provider interaction
@@ -143,7 +143,7 @@ final class ConfigurationServiceTests: XCTestCase {
 
         createService(providers: [provider])
         _ = sut.isFeatureEnabled(customKey)
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
     }
 
     func test_gets_provider_data_value_when_checking_app_update() {
@@ -167,7 +167,7 @@ final class ConfigurationServiceTests: XCTestCase {
             })
             .store(in: &subscriptions)
 
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
     }
 
     func test_gets_provider_bool_value_when_checking_custom_key() {
@@ -182,7 +182,7 @@ final class ConfigurationServiceTests: XCTestCase {
 
         createService(providers: [provider])
         _ = sut.isFeatureEnabled(customKey)
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
     }
 
     func test_calls_all_available_providers_when_checking_custom_key() {
@@ -205,7 +205,7 @@ final class ConfigurationServiceTests: XCTestCase {
 
         createService(providers: [provider1, provider2])
         _ = sut.isFeatureEnabled(customKey)
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
     }
 
     func test_uses_first_valid_provider_value_when_checking_custom_key() {
@@ -230,7 +230,7 @@ final class ConfigurationServiceTests: XCTestCase {
 
         createService(providers: [provider1, provider2])
         let result = sut.isFeatureEnabled(customKey)
-        wait(for: [expectation1, expectation2], timeout: inverted)
+        wait(for: [expectation1, expectation2], timeout: .inverted)
         XCTAssertTrue(result)
     }
 
@@ -343,7 +343,7 @@ final class ConfigurationServiceTests: XCTestCase {
 
         provider.isReadySubject.value = true
 
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
 
         // force and soft update available
         XCTAssertNotNil(sut.softAppUpdateInfo)
@@ -366,7 +366,7 @@ final class ConfigurationServiceTests: XCTestCase {
 
         createService(providers: [provider])
         let result = sut.isFeatureEnabled(customKey)
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
         XCTAssertFalse(result)
     }
 

--- a/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/ConfigurationServiceTests.swift
+++ b/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/ConfigurationServiceTests.swift
@@ -42,7 +42,7 @@ final class ConfigurationServiceTests: XCTestCase {
             })
             .store(in: &subscriptions)
 
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: .default)
     }
 
     func test_publishes_updated_feature_availability_after_dependency_updates() {
@@ -71,7 +71,7 @@ final class ConfigurationServiceTests: XCTestCase {
             })
             .store(in: &subscriptions)
 
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: .default)
     }
 
     func test_publishes_updated_feature_availability_when_providers_become_ready() {
@@ -104,7 +104,7 @@ final class ConfigurationServiceTests: XCTestCase {
             })
             .store(in: &subscriptions)
 
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: .default)
     }
 
     // MARK: - Test provider interaction
@@ -167,7 +167,7 @@ final class ConfigurationServiceTests: XCTestCase {
             })
             .store(in: &subscriptions)
 
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: .default)
     }
 
     func test_gets_provider_bool_value_when_checking_custom_key() {
@@ -205,7 +205,7 @@ final class ConfigurationServiceTests: XCTestCase {
 
         createService(providers: [provider1, provider2])
         _ = sut.isFeatureEnabled(customKey)
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: .default)
     }
 
     func test_uses_first_valid_provider_value_when_checking_custom_key() {
@@ -343,7 +343,7 @@ final class ConfigurationServiceTests: XCTestCase {
 
         provider.isReadySubject.value = true
 
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: .default)
 
         // force and soft update available
         XCTAssertNotNil(sut.softAppUpdateInfo)
@@ -366,7 +366,7 @@ final class ConfigurationServiceTests: XCTestCase {
 
         createService(providers: [provider])
         let result = sut.isFeatureEnabled(customKey)
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: .default)
         XCTAssertFalse(result)
     }
 

--- a/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/ConfigurationServiceTests.swift
+++ b/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/ConfigurationServiceTests.swift
@@ -42,7 +42,7 @@ final class ConfigurationServiceTests: XCTestCase {
             })
             .store(in: &subscriptions)
 
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: `default`)
     }
 
     func test_publishes_updated_feature_availability_after_dependency_updates() {
@@ -71,7 +71,7 @@ final class ConfigurationServiceTests: XCTestCase {
             })
             .store(in: &subscriptions)
 
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: `default`)
     }
 
     func test_publishes_updated_feature_availability_when_providers_become_ready() {
@@ -104,7 +104,7 @@ final class ConfigurationServiceTests: XCTestCase {
             })
             .store(in: &subscriptions)
 
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: `default`)
     }
 
     // MARK: - Test provider interaction
@@ -143,7 +143,7 @@ final class ConfigurationServiceTests: XCTestCase {
 
         createService(providers: [provider])
         _ = sut.isFeatureEnabled(customKey)
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: `default`)
     }
 
     func test_gets_provider_data_value_when_checking_app_update() {
@@ -167,7 +167,7 @@ final class ConfigurationServiceTests: XCTestCase {
             })
             .store(in: &subscriptions)
 
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: `default`)
     }
 
     func test_gets_provider_bool_value_when_checking_custom_key() {
@@ -182,7 +182,7 @@ final class ConfigurationServiceTests: XCTestCase {
 
         createService(providers: [provider])
         _ = sut.isFeatureEnabled(customKey)
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: `default`)
     }
 
     func test_calls_all_available_providers_when_checking_custom_key() {
@@ -205,7 +205,7 @@ final class ConfigurationServiceTests: XCTestCase {
 
         createService(providers: [provider1, provider2])
         _ = sut.isFeatureEnabled(customKey)
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: `default`)
     }
 
     func test_uses_first_valid_provider_value_when_checking_custom_key() {
@@ -230,7 +230,7 @@ final class ConfigurationServiceTests: XCTestCase {
 
         createService(providers: [provider1, provider2])
         let result = sut.isFeatureEnabled(customKey)
-        wait(for: [expectation1, expectation2], timeout: defaultTimeout)
+        wait(for: [expectation1, expectation2], timeout: inverted)
         XCTAssertTrue(result)
     }
 
@@ -343,7 +343,7 @@ final class ConfigurationServiceTests: XCTestCase {
 
         provider.isReadySubject.value = true
 
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: `default`)
 
         // force and soft update available
         XCTAssertNotNil(sut.softAppUpdateInfo)
@@ -366,7 +366,7 @@ final class ConfigurationServiceTests: XCTestCase {
 
         createService(providers: [provider])
         let result = sut.isFeatureEnabled(customKey)
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: `default`)
         XCTAssertFalse(result)
     }
 

--- a/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/DeepLinkServiceTests.swift
+++ b/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/DeepLinkServiceTests.swift
@@ -72,7 +72,7 @@ final class DeepLinkServiceTests: XCTestCase {
 
         sut = .init(parsers: [parser1, parser2, parser3], configuration: configuration, log: log)
         let result = sut.canHandleUrl(testUrl)
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
         XCTAssertFalse(result)
     }
 
@@ -96,7 +96,7 @@ final class DeepLinkServiceTests: XCTestCase {
         sut = .init(parsers: [parser1, parser2], configuration: configuration, log: log)
         let result = sut.canHandleUrl(testUrl)
 
-        wait(for: [calledExpectation, notCalledExpectation], timeout: inverted)
+        wait(for: [calledExpectation, notCalledExpectation], timeout: .inverted)
         XCTAssertFalse(result, "Expected canHandleUrl to return false because no handlers were added.")
     }
 
@@ -135,7 +135,7 @@ final class DeepLinkServiceTests: XCTestCase {
 
         sut = .init(parsers: [parser], handlers: [handler], configuration: configuration, log: log)
         sut.openUrls([])
-        wait(for: [expectation], timeout: inverted)
+        wait(for: [expectation], timeout: .inverted)
     }
 
     func test_uses_fallback_link_when_opening_url_if_no_parsers_are_available() {
@@ -155,7 +155,7 @@ final class DeepLinkServiceTests: XCTestCase {
 
         sut = .init(parsers: [], handlers: [handler], configuration: configuration, log: log)
         sut.openUrls([testUrl])
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
     }
 
     func test_does_nothing_when_opening_url_if_no_capable_handlers_are_available() {
@@ -173,7 +173,7 @@ final class DeepLinkServiceTests: XCTestCase {
 
         sut = .init(parsers: [], handlers: [handler], configuration: configuration, log: log)
         sut.openUrls([testUrl])
-        wait(for: [expectation], timeout: inverted)
+        wait(for: [expectation], timeout: .inverted)
     }
 
     func test_uses_first_valid_parser_result_when_opening_url() {
@@ -210,7 +210,7 @@ final class DeepLinkServiceTests: XCTestCase {
         sut = .init(parsers: [parser1, parser2], handlers: [handler], configuration: configuration, log: log)
         sut.openUrls([testUrl])
 
-        wait(for: [calledExpectation, notCalledExpectation, handlerCallExpectation], timeout: inverted)
+        wait(for: [calledExpectation, notCalledExpectation, handlerCallExpectation], timeout: .inverted)
     }
 
     func test_uses_first_capable_handler_when_opening_url() {
@@ -242,6 +242,6 @@ final class DeepLinkServiceTests: XCTestCase {
 
         sut = .init(parsers: [], handlers: [handler1, handler2], configuration: configuration, log: log)
         sut.openUrls([testUrl])
-        wait(for: [calledExpectation, notCalledExpectation], timeout: inverted)
+        wait(for: [calledExpectation, notCalledExpectation], timeout: .inverted)
     }
 }

--- a/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/DeepLinkServiceTests.swift
+++ b/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/DeepLinkServiceTests.swift
@@ -72,13 +72,14 @@ final class DeepLinkServiceTests: XCTestCase {
 
         sut = .init(parsers: [parser1, parser2, parser3], configuration: configuration, log: log)
         let result = sut.canHandleUrl(testUrl)
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: `default`)
         XCTAssertFalse(result)
     }
 
     func test_uses_first_valid_parser_result_when_checking_if_can_handle_url() {
         let calledExpectation = expectation(description: "wait for valid parser call")
         let parser1 = MockDeepLinkParser(configuration: configuration)
+
         parser1.onParseUrlCalled = { _ in
             calledExpectation.fulfill()
             return DeepLink(type: .webView(url: self.testUrl), fullUrl: self.testUrl)
@@ -94,8 +95,9 @@ final class DeepLinkServiceTests: XCTestCase {
 
         sut = .init(parsers: [parser1, parser2], configuration: configuration, log: log)
         let result = sut.canHandleUrl(testUrl)
-        wait(for: [calledExpectation, notCalledExpectation], timeout: defaultTimeout)
-        XCTAssertFalse(result) // False because no handlers were added
+
+        wait(for: [calledExpectation, notCalledExpectation], timeout: inverted)
+        XCTAssertFalse(result, "Expected canHandleUrl to return false because no handlers were added.")
     }
 
     func test_can_handle_url_if_at_least_one_capable_handler_and_parser_are_available() {
@@ -133,7 +135,7 @@ final class DeepLinkServiceTests: XCTestCase {
 
         sut = .init(parsers: [parser], handlers: [handler], configuration: configuration, log: log)
         sut.openUrls([])
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: inverted)
     }
 
     func test_uses_fallback_link_when_opening_url_if_no_parsers_are_available() {
@@ -153,7 +155,7 @@ final class DeepLinkServiceTests: XCTestCase {
 
         sut = .init(parsers: [], handlers: [handler], configuration: configuration, log: log)
         sut.openUrls([testUrl])
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: `default`)
     }
 
     func test_does_nothing_when_opening_url_if_no_capable_handlers_are_available() {
@@ -164,18 +166,20 @@ final class DeepLinkServiceTests: XCTestCase {
         handler.onCanHandleDeepLinkCalled = { _ in
             return false
         }
-        handler.onHandleDeepLinkCalled = { deepLink in
+
+        handler.onHandleDeepLinkCalled = { _ in
             expectation.fulfill()
         }
 
         sut = .init(parsers: [], handlers: [handler], configuration: configuration, log: log)
         sut.openUrls([testUrl])
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: inverted)
     }
 
     func test_uses_first_valid_parser_result_when_opening_url() {
         let calledExpectation = expectation(description: "wait for valid parser call")
         let parser1 = MockDeepLinkParser(configuration: configuration)
+
         parser1.onParseUrlCalled = { _ in
             calledExpectation.fulfill()
             return DeepLink(type: .home, fullUrl: self.testUrl)
@@ -184,6 +188,7 @@ final class DeepLinkServiceTests: XCTestCase {
         let notCalledExpectation = expectation(description: "wait for invalid parser call")
         notCalledExpectation.isInverted = true
         let parser2 = MockDeepLinkParser(configuration: configuration)
+
         parser2.onParseUrlCalled = { _ in
             notCalledExpectation.fulfill()
             return DeepLink(type: .webView(url: self.testUrl), fullUrl: self.testUrl)
@@ -191,9 +196,11 @@ final class DeepLinkServiceTests: XCTestCase {
 
         let handlerCallExpectation = expectation(description: "wait for handler call")
         let handler = MockDeepLinkHandler()
+
         handler.onCanHandleDeepLinkCalled = { _ in
             return true
         }
+
         handler.onHandleDeepLinkCalled = { deepLink in
             XCTAssertEqual(deepLink.type, .home)
             XCTAssertEqual(deepLink.fullUrl.absoluteString, self.testUrl.absoluteString)
@@ -202,12 +209,14 @@ final class DeepLinkServiceTests: XCTestCase {
 
         sut = .init(parsers: [parser1, parser2], handlers: [handler], configuration: configuration, log: log)
         sut.openUrls([testUrl])
-        wait(for: [calledExpectation, notCalledExpectation, handlerCallExpectation], timeout: defaultTimeout)
+
+        wait(for: [calledExpectation, notCalledExpectation, handlerCallExpectation], timeout: inverted)
     }
 
     func test_uses_first_capable_handler_when_opening_url() {
         let calledExpectation = expectation(description: "wait for handler call")
         let handler1 = MockDeepLinkHandler()
+
         handler1.onCanHandleDeepLinkCalled = { _ in
             true
         }
@@ -233,6 +242,6 @@ final class DeepLinkServiceTests: XCTestCase {
 
         sut = .init(parsers: [], handlers: [handler1, handler2], configuration: configuration, log: log)
         sut.openUrls([testUrl])
-        wait(for: [calledExpectation, notCalledExpectation], timeout: defaultTimeout)
+        wait(for: [calledExpectation, notCalledExpectation], timeout: inverted)
     }
 }

--- a/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/DeepLinkServiceTests.swift
+++ b/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/DeepLinkServiceTests.swift
@@ -72,7 +72,7 @@ final class DeepLinkServiceTests: XCTestCase {
 
         sut = .init(parsers: [parser1, parser2, parser3], configuration: configuration, log: log)
         let result = sut.canHandleUrl(testUrl)
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: .default)
         XCTAssertFalse(result)
     }
 
@@ -155,7 +155,7 @@ final class DeepLinkServiceTests: XCTestCase {
 
         sut = .init(parsers: [], handlers: [handler], configuration: configuration, log: log)
         sut.openUrls([testUrl])
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: .default)
     }
 
     func test_does_nothing_when_opening_url_if_no_capable_handlers_are_available() {

--- a/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/NavigationServiceTests.swift
+++ b/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/NavigationServiceTests.swift
@@ -34,6 +34,6 @@ final class NavigationServiceTests: XCTestCase {
         Task {
             _ = try await sut.getNavigationItems(for: .shop)
         }
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: `default`)
     }
 }

--- a/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/NavigationServiceTests.swift
+++ b/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/NavigationServiceTests.swift
@@ -34,6 +34,6 @@ final class NavigationServiceTests: XCTestCase {
         Task {
             _ = try await sut.getNavigationItems(for: .shop)
         }
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: .default)
     }
 }

--- a/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/NavigationServiceTests.swift
+++ b/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/NavigationServiceTests.swift
@@ -34,6 +34,6 @@ final class NavigationServiceTests: XCTestCase {
         Task {
             _ = try await sut.getNavigationItems(for: .shop)
         }
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
     }
 }

--- a/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/ProductListingServiceTests.swift
+++ b/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/ProductListingServiceTests.swift
@@ -42,7 +42,7 @@ final class ProductListingServiceTests: XCTestCase {
             _ = try await sut.paged(categoryId: "category id", query: "query", sort: "sort")
         }
 
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: .default)
     }
 
     func test_pagination_info_provides_next_page() {
@@ -56,7 +56,7 @@ final class ProductListingServiceTests: XCTestCase {
             _ = try await sut.paged()
         }
 
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: .default)
         XCTAssertTrue(sut.hasNext())
     }
 
@@ -71,7 +71,7 @@ final class ProductListingServiceTests: XCTestCase {
             _ = try await sut.paged()
         }
 
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: .default)
         XCTAssertEqual(sut.totalOfRecords, 101)
     }
 
@@ -86,7 +86,7 @@ final class ProductListingServiceTests: XCTestCase {
             _ = try await sut.paged()
         }
 
-        wait(for: [calledExpectation])
+        wait(for: [calledExpectation], timeout: .default)
 
         XCTAssertFalse(sut.hasNext())
 
@@ -134,6 +134,6 @@ final class ProductListingServiceTests: XCTestCase {
             XCTAssertEqual(sort, "sort 3")
         }
 
-        await fulfillment(of: [expectation])
+        await fulfillment(of: [expectation], timeout: .default)
     }
 }

--- a/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/ProductListingServiceTests.swift
+++ b/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/ProductListingServiceTests.swift
@@ -42,7 +42,7 @@ final class ProductListingServiceTests: XCTestCase {
             _ = try await sut.paged(categoryId: "category id", query: "query", sort: "sort")
         }
 
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: `default`)
     }
 
     func test_pagination_info_provides_next_page() {
@@ -56,7 +56,7 @@ final class ProductListingServiceTests: XCTestCase {
             _ = try await sut.paged()
         }
 
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: `default`)
         XCTAssertTrue(sut.hasNext())
     }
 
@@ -71,7 +71,7 @@ final class ProductListingServiceTests: XCTestCase {
             _ = try await sut.paged()
         }
 
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: `default`)
         XCTAssertEqual(sut.totalOfRecords, 101)
     }
 
@@ -86,7 +86,7 @@ final class ProductListingServiceTests: XCTestCase {
             _ = try await sut.paged()
         }
 
-        wait(for: [calledExpectation], timeout: defaultTimeout)
+        wait(for: [calledExpectation], timeout: `default`)
 
         XCTAssertFalse(sut.hasNext())
 
@@ -101,7 +101,7 @@ final class ProductListingServiceTests: XCTestCase {
             _ = try await sut.next()
         }
 
-        wait(for: [notCalledExpectation], timeout: defaultTimeout)
+        wait(for: [notCalledExpectation], timeout: inverted)
     }
 
     func test_next_page_calls_bff_service_while_has_next_pages() async {
@@ -134,6 +134,6 @@ final class ProductListingServiceTests: XCTestCase {
             XCTAssertEqual(sort, "sort 3")
         }
 
-        await fulfillment(of: [expectation], timeout: defaultTimeout)
+        await fulfillment(of: [expectation], timeout: `default`)
     }
 }

--- a/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/ProductListingServiceTests.swift
+++ b/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/ProductListingServiceTests.swift
@@ -42,7 +42,7 @@ final class ProductListingServiceTests: XCTestCase {
             _ = try await sut.paged(categoryId: "category id", query: "query", sort: "sort")
         }
 
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
     }
 
     func test_pagination_info_provides_next_page() {
@@ -56,7 +56,7 @@ final class ProductListingServiceTests: XCTestCase {
             _ = try await sut.paged()
         }
 
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
         XCTAssertTrue(sut.hasNext())
     }
 
@@ -71,7 +71,7 @@ final class ProductListingServiceTests: XCTestCase {
             _ = try await sut.paged()
         }
 
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
         XCTAssertEqual(sut.totalOfRecords, 101)
     }
 
@@ -86,7 +86,7 @@ final class ProductListingServiceTests: XCTestCase {
             _ = try await sut.paged()
         }
 
-        wait(for: [calledExpectation], timeout: `default`)
+        wait(for: [calledExpectation])
 
         XCTAssertFalse(sut.hasNext())
 
@@ -101,7 +101,7 @@ final class ProductListingServiceTests: XCTestCase {
             _ = try await sut.next()
         }
 
-        wait(for: [notCalledExpectation], timeout: inverted)
+        wait(for: [notCalledExpectation], timeout: .inverted)
     }
 
     func test_next_page_calls_bff_service_while_has_next_pages() async {
@@ -134,6 +134,6 @@ final class ProductListingServiceTests: XCTestCase {
             XCTAssertEqual(sort, "sort 3")
         }
 
-        await fulfillment(of: [expectation], timeout: `default`)
+        await fulfillment(of: [expectation])
     }
 }

--- a/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/ProductServiceTests.swift
+++ b/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/ProductServiceTests.swift
@@ -32,7 +32,7 @@ final class ProductServiceTests: XCTestCase {
         Task {
             _ = try await sut.getProduct(id: "id")
         }
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: .default)
     }
 
     func test_get_product_throws_no_product_error_when_not_found() {
@@ -49,7 +49,7 @@ final class ProductServiceTests: XCTestCase {
                 expectation.fulfill()
             }
         }
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: .default)
     }
 
     func test_get_product_throws_generic_error_when_bff_service_fails() {
@@ -66,7 +66,7 @@ final class ProductServiceTests: XCTestCase {
                 expectation.fulfill()
             }
         }
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: .default)
     }
 
     // MARK: - Get Product List
@@ -92,6 +92,6 @@ final class ProductServiceTests: XCTestCase {
                 sort: "sort"
             )
         }
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: .default)
     }
 }

--- a/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/ProductServiceTests.swift
+++ b/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/ProductServiceTests.swift
@@ -32,7 +32,7 @@ final class ProductServiceTests: XCTestCase {
         Task {
             _ = try await sut.getProduct(id: "id")
         }
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: `default`)
     }
 
     func test_get_product_throws_no_product_error_when_not_found() {
@@ -49,7 +49,7 @@ final class ProductServiceTests: XCTestCase {
                 expectation.fulfill()
             }
         }
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: `default`)
     }
 
     func test_get_product_throws_generic_error_when_bff_service_fails() {
@@ -66,7 +66,7 @@ final class ProductServiceTests: XCTestCase {
                 expectation.fulfill()
             }
         }
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: `default`)
     }
 
     // MARK: - Get Product List
@@ -92,6 +92,6 @@ final class ProductServiceTests: XCTestCase {
                 sort: "sort"
             )
         }
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: `default`)
     }
 }

--- a/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/ProductServiceTests.swift
+++ b/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/ProductServiceTests.swift
@@ -32,7 +32,7 @@ final class ProductServiceTests: XCTestCase {
         Task {
             _ = try await sut.getProduct(id: "id")
         }
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
     }
 
     func test_get_product_throws_no_product_error_when_not_found() {
@@ -49,7 +49,7 @@ final class ProductServiceTests: XCTestCase {
                 expectation.fulfill()
             }
         }
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
     }
 
     func test_get_product_throws_generic_error_when_bff_service_fails() {
@@ -66,7 +66,7 @@ final class ProductServiceTests: XCTestCase {
                 expectation.fulfill()
             }
         }
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
     }
 
     // MARK: - Get Product List
@@ -92,6 +92,6 @@ final class ProductServiceTests: XCTestCase {
                 sort: "sort"
             )
         }
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
     }
 }

--- a/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/ReachabilityServiceTests.swift
+++ b/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/ReachabilityServiceTests.swift
@@ -62,36 +62,28 @@ final class ReachabilityServiceTests: XCTestCase {
         // Initialize `isAvailable` to `true` to ensure the event triggers, as repeated events are filtered out.
         mockMonitor.isAvailable = true
 
-        let resultUnavailable = XCTAssertEmitsValue(
+        XCTAssertEmitsValueEqualTo(
             from: sut.networkAvailability,
-            afterTrigger: { mockMonitor.isAvailable = false }
+            expectedValue: false,
+            afterTrigger: { self.mockMonitor.isAvailable = false }
         )
 
-        XCTAssertEqual(resultUnavailable, false)
-
-        let resultAvailable = XCTAssertEmitsValue(
+        XCTAssertEmitsValueEqualTo(
             from: sut.networkAvailability,
-            afterTrigger: { mockMonitor.isAvailable = true }
+            expectedValue: true,
+            afterTrigger: { self.mockMonitor.isAvailable = true }
         )
-
-        XCTAssertEqual(resultAvailable, true)
     }
 
     func test_reachabilityService_storesCurrentNetworkAvailability() {
         // Initialize `isAvailable` to `true` to ensure the event triggers, as repeated events are filtered out.
         mockMonitor.isAvailable = true
 
-        XCTAssertEmitsValue(
-            from: sut.networkAvailability,
-            afterTrigger: { mockMonitor.isAvailable = false }
-        )
+        XCTAssertEmitsValue(from: sut.networkAvailability, afterTrigger: { self.mockMonitor.isAvailable = false })
 
         XCTAssertFalse(sut.isNetworkAvailable)
 
-        XCTAssertEmitsValue(
-            from: sut.networkAvailability,
-            afterTrigger: { mockMonitor.isAvailable = true }
-        )
+        XCTAssertEmitsValue(from: sut.networkAvailability, afterTrigger: { self.mockMonitor.isAvailable = true })
 
         XCTAssertTrue(sut.isNetworkAvailable)
     }

--- a/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/ReachabilityServiceTests.swift
+++ b/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/ReachabilityServiceTests.swift
@@ -62,15 +62,15 @@ final class ReachabilityServiceTests: XCTestCase {
         // Initialize `isAvailable` to `true` to ensure the event triggers, as repeated events are filtered out.
         mockMonitor.isAvailable = true
 
-        let resultUnavailable = captureEvent(
-            fromPublisher: sut.networkAvailability.eraseToAnyPublisher(),
+        let resultUnavailable = XCTAssertEmitsValue(
+            from: sut.networkAvailability,
             afterTrigger: { mockMonitor.isAvailable = false }
         )
 
         XCTAssertEqual(resultUnavailable, false)
 
-        let resultAvailable = captureEvent(
-            fromPublisher: sut.networkAvailability.eraseToAnyPublisher(),
+        let resultAvailable = XCTAssertEmitsValue(
+            from: sut.networkAvailability,
             afterTrigger: { mockMonitor.isAvailable = true }
         )
 
@@ -81,15 +81,15 @@ final class ReachabilityServiceTests: XCTestCase {
         // Initialize `isAvailable` to `true` to ensure the event triggers, as repeated events are filtered out.
         mockMonitor.isAvailable = true
 
-       captureEvent(
-            fromPublisher: sut.networkAvailability.eraseToAnyPublisher(),
+        XCTAssertEmitsValue(
+            from: sut.networkAvailability,
             afterTrigger: { mockMonitor.isAvailable = false }
         )
 
         XCTAssertFalse(sut.isNetworkAvailable)
 
-        captureEvent(
-            fromPublisher: sut.networkAvailability.eraseToAnyPublisher(),
+        XCTAssertEmitsValue(
+            from: sut.networkAvailability,
             afterTrigger: { mockMonitor.isAvailable = true }
         )
 

--- a/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/SearchServiceTests.swift
+++ b/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/SearchServiceTests.swift
@@ -31,6 +31,6 @@ final class SearchServiceTests: XCTestCase {
         Task {
             _ = try await sut.getSuggestion(term: searchTerm)
         }
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: .default)
     }
 }

--- a/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/SearchServiceTests.swift
+++ b/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/SearchServiceTests.swift
@@ -31,6 +31,6 @@ final class SearchServiceTests: XCTestCase {
         Task {
             _ = try await sut.getSuggestion(term: searchTerm)
         }
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
     }
 }

--- a/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/SearchServiceTests.swift
+++ b/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/SearchServiceTests.swift
@@ -31,6 +31,6 @@ final class SearchServiceTests: XCTestCase {
         Task {
             _ = try await sut.getSuggestion(term: searchTerm)
         }
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: `default`)
     }
 }

--- a/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/WebViewConfigurationServiceTests.swift
+++ b/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/WebViewConfigurationServiceTests.swift
@@ -29,8 +29,8 @@ final class WebViewConfigurationServiceTests: XCTestCase {
             expectation.fulfill()
             return WebViewConfiguration(configuration: [:])
         }
-        sut = .init( bffClient: mockClientService, log: log)
-        wait(for: [expectation], timeout: defaultTimeout)
+        sut = .init(bffClient: mockClientService, log: log)
+        wait(for: [expectation], timeout: `default`)
     }
 
     func test_configuration_is_fetched_if_unavailable_when_url_is_requested() {
@@ -41,7 +41,7 @@ final class WebViewConfigurationServiceTests: XCTestCase {
             throw BFFRequestError(type: .generic)
         }
         sut = .init(bffClient: mockClientService, log: log)
-        wait(for: [firstExpectation], timeout: defaultTimeout)
+        wait(for: [firstExpectation], timeout: `default`)
 
         // Now prepare the mock to return a valid configuration
         let secondExpectation = expectation(description: "Wait for service call")
@@ -53,7 +53,7 @@ final class WebViewConfigurationServiceTests: XCTestCase {
         Task {
             _ = await sut.url(for: .addresses)
         }
-        wait(for: [secondExpectation], timeout: defaultTimeout)
+        wait(for: [secondExpectation], timeout: `default`)
     }
 
     func test_feature_url_is_returned_when_configuration_is_available() {
@@ -64,7 +64,7 @@ final class WebViewConfigurationServiceTests: XCTestCase {
             return WebViewConfiguration(configuration: [.addresses: url])
         }
         sut = .init(bffClient: mockClientService, log: log)
-        wait(for: [firstExpectation], timeout: defaultTimeout)
+        wait(for: [firstExpectation], timeout: `default`)
 
         let secondExpectation = expectation(description: "Wait for return")
         Task {
@@ -72,7 +72,7 @@ final class WebViewConfigurationServiceTests: XCTestCase {
             XCTAssertEqual(result?.absoluteString, url.absoluteString)
             secondExpectation.fulfill()
         }
-        wait(for: [secondExpectation], timeout: defaultTimeout)
+        wait(for: [secondExpectation], timeout: `default`)
     }
 
     func test_feature_url_is_nil_when_configuration_is_not_available() {
@@ -90,6 +90,6 @@ final class WebViewConfigurationServiceTests: XCTestCase {
             XCTAssertNil(result)
             secondExpectation.fulfill()
         }
-        wait(for: [firstExpectation, secondExpectation], timeout: defaultTimeout)
+        wait(for: [firstExpectation, secondExpectation], timeout: `default`)
     }
 }

--- a/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/WebViewConfigurationServiceTests.swift
+++ b/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/WebViewConfigurationServiceTests.swift
@@ -30,7 +30,7 @@ final class WebViewConfigurationServiceTests: XCTestCase {
             return WebViewConfiguration(configuration: [:])
         }
         sut = .init(bffClient: mockClientService, log: log)
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: .default)
     }
 
     func test_configuration_is_fetched_if_unavailable_when_url_is_requested() {
@@ -41,7 +41,7 @@ final class WebViewConfigurationServiceTests: XCTestCase {
             throw BFFRequestError(type: .generic)
         }
         sut = .init(bffClient: mockClientService, log: log)
-        wait(for: [firstExpectation])
+        wait(for: [firstExpectation], timeout: .default)
 
         // Now prepare the mock to return a valid configuration
         let secondExpectation = expectation(description: "Wait for service call")
@@ -53,7 +53,7 @@ final class WebViewConfigurationServiceTests: XCTestCase {
         Task {
             _ = await sut.url(for: .addresses)
         }
-        wait(for: [secondExpectation])
+        wait(for: [secondExpectation], timeout: .default)
     }
 
     func test_feature_url_is_returned_when_configuration_is_available() {
@@ -64,7 +64,7 @@ final class WebViewConfigurationServiceTests: XCTestCase {
             return WebViewConfiguration(configuration: [.addresses: url])
         }
         sut = .init(bffClient: mockClientService, log: log)
-        wait(for: [firstExpectation])
+        wait(for: [firstExpectation], timeout: .default)
 
         let secondExpectation = expectation(description: "Wait for return")
         Task {
@@ -72,7 +72,7 @@ final class WebViewConfigurationServiceTests: XCTestCase {
             XCTAssertEqual(result?.absoluteString, url.absoluteString)
             secondExpectation.fulfill()
         }
-        wait(for: [secondExpectation])
+        wait(for: [secondExpectation], timeout: .default)
     }
 
     func test_feature_url_is_nil_when_configuration_is_not_available() {
@@ -90,6 +90,6 @@ final class WebViewConfigurationServiceTests: XCTestCase {
             XCTAssertNil(result)
             secondExpectation.fulfill()
         }
-        wait(for: [firstExpectation, secondExpectation])
+        wait(for: [firstExpectation, secondExpectation], timeout: .default)
     }
 }

--- a/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/WebViewConfigurationServiceTests.swift
+++ b/Alfie/AlfieKit/Tests/CoreTests/ServiceTests/WebViewConfigurationServiceTests.swift
@@ -30,7 +30,7 @@ final class WebViewConfigurationServiceTests: XCTestCase {
             return WebViewConfiguration(configuration: [:])
         }
         sut = .init(bffClient: mockClientService, log: log)
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
     }
 
     func test_configuration_is_fetched_if_unavailable_when_url_is_requested() {
@@ -41,7 +41,7 @@ final class WebViewConfigurationServiceTests: XCTestCase {
             throw BFFRequestError(type: .generic)
         }
         sut = .init(bffClient: mockClientService, log: log)
-        wait(for: [firstExpectation], timeout: `default`)
+        wait(for: [firstExpectation])
 
         // Now prepare the mock to return a valid configuration
         let secondExpectation = expectation(description: "Wait for service call")
@@ -53,7 +53,7 @@ final class WebViewConfigurationServiceTests: XCTestCase {
         Task {
             _ = await sut.url(for: .addresses)
         }
-        wait(for: [secondExpectation], timeout: `default`)
+        wait(for: [secondExpectation])
     }
 
     func test_feature_url_is_returned_when_configuration_is_available() {
@@ -64,7 +64,7 @@ final class WebViewConfigurationServiceTests: XCTestCase {
             return WebViewConfiguration(configuration: [.addresses: url])
         }
         sut = .init(bffClient: mockClientService, log: log)
-        wait(for: [firstExpectation], timeout: `default`)
+        wait(for: [firstExpectation])
 
         let secondExpectation = expectation(description: "Wait for return")
         Task {
@@ -72,7 +72,7 @@ final class WebViewConfigurationServiceTests: XCTestCase {
             XCTAssertEqual(result?.absoluteString, url.absoluteString)
             secondExpectation.fulfill()
         }
-        wait(for: [secondExpectation], timeout: `default`)
+        wait(for: [secondExpectation])
     }
 
     func test_feature_url_is_nil_when_configuration_is_not_available() {
@@ -90,6 +90,6 @@ final class WebViewConfigurationServiceTests: XCTestCase {
             XCTAssertNil(result)
             secondExpectation.fulfill()
         }
-        wait(for: [firstExpectation, secondExpectation], timeout: `default`)
+        wait(for: [firstExpectation, secondExpectation])
     }
 }

--- a/Alfie/AlfieTests/Features/BrandsViewModelTests.swift
+++ b/Alfie/AlfieTests/Features/BrandsViewModelTests.swift
@@ -32,10 +32,7 @@ final class BrandsViewModelTests: XCTestCase {
             []
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state,
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state, afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertTrue(sut.state.didFail)
 
@@ -43,10 +40,7 @@ final class BrandsViewModelTests: XCTestCase {
             [.fixture(name: "Brand 1")]
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state,
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state, afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertTrue(sut.state.isLoading)
     }
@@ -56,10 +50,7 @@ final class BrandsViewModelTests: XCTestCase {
             [.fixture(name: "Brand 1")]
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state,
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state, afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertFalse(sut.state.isLoading)
         XCTAssertTrue(sut.state.isSuccess)
@@ -70,10 +61,7 @@ final class BrandsViewModelTests: XCTestCase {
             [Brand.fixture(name: "brand")]
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertTrue(sut.state.isSuccess)
     }
@@ -83,10 +71,7 @@ final class BrandsViewModelTests: XCTestCase {
             []
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertTrue(sut.state.didFail)
         XCTAssertEqual(sut.state.failure, .noResults)
@@ -97,10 +82,7 @@ final class BrandsViewModelTests: XCTestCase {
             throw BFFRequestError(type: .generic)
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertTrue(sut.state.didFail)
         XCTAssertEqual(sut.state.failure, .generic)
@@ -116,7 +98,7 @@ final class BrandsViewModelTests: XCTestCase {
         }
 
         sut.viewDidAppear()
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
     }
 
     func test_ignores_load_brands_when_view_appears_but_brands_were_loaded_before() {
@@ -135,7 +117,7 @@ final class BrandsViewModelTests: XCTestCase {
             }
 
         sut.viewDidAppear()
-        wait(for: [firstExpectation, secondExpectation], timeout: `default`)
+        wait(for: [firstExpectation, secondExpectation])
 
         let thirdExpectation = expectation(description: "Wait for no service call")
         thirdExpectation.isInverted = true
@@ -145,7 +127,7 @@ final class BrandsViewModelTests: XCTestCase {
         }
 
         sut.viewDidAppear()
-        wait(for: [thirdExpectation], timeout: inverted)
+        wait(for: [thirdExpectation], timeout: .inverted)
         cancellable.cancel()
     }
 
@@ -157,10 +139,7 @@ final class BrandsViewModelTests: XCTestCase {
             fixtures
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertEqual(sut.sectionTitles.count, 2)
         XCTAssertEqual(sut.state.value?.keys.count, sut.sectionTitles.count)
@@ -172,10 +151,7 @@ final class BrandsViewModelTests: XCTestCase {
             throw BFFRequestError(type: .generic)
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertTrue(sut.sectionTitles.isEmpty)
         XCTAssertTrue(sut.state.didFail)
@@ -187,10 +163,7 @@ final class BrandsViewModelTests: XCTestCase {
             fixtures
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         let expectedSections = OrderedSet(arrayLiteral: "A", "B", "C")
         XCTAssertEqual(sut.sectionTitles.count, 3)
@@ -208,10 +181,7 @@ final class BrandsViewModelTests: XCTestCase {
             fixtures
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertEqual(sut.brands(for: "A").count, 2)
         XCTAssertEqual(sut.brands(for: "B").count, 1)
@@ -226,10 +196,7 @@ final class BrandsViewModelTests: XCTestCase {
             .mockBrands
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertEqual(sut.sectionTitles, OrderedSet(arrayLiteral: "A", "B", "C"))
 
@@ -245,10 +212,7 @@ final class BrandsViewModelTests: XCTestCase {
             .mockBrands
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertEqual(sut.sectionTitles, OrderedSet(arrayLiteral: "A", "B", "C"))
 
@@ -262,10 +226,7 @@ final class BrandsViewModelTests: XCTestCase {
             .mockBrands
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         sut.searchText = "Alfie "
         XCTAssertEqual(sut.sectionTitles, OrderedSet(arrayLiteral: "A"))
@@ -279,20 +240,16 @@ final class BrandsViewModelTests: XCTestCase {
             .mockBrands
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
-        let indexVisibilityPublisher = XCTAssertEmitsValue(
+        XCTAssertEmitsValueEqualTo(
             from: sut.indexVisibilityPublisher,
+            expectedValue: true,
             afterTrigger: {
-                sut.searchText = ""
-                sut.searchFocusDidChange(isFocused: false)
+                self.sut.searchText = ""
+                self.sut.searchFocusDidChange(isFocused: false)
             }
         )
-
-        XCTAssertEqual(indexVisibilityPublisher, true)
     }
 
     func test_brands_index_hidden_with_focused_search_and_no_query() {
@@ -300,20 +257,16 @@ final class BrandsViewModelTests: XCTestCase {
             .mockBrands
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
-        let indexVisibilityPublisher = XCTAssertEmitsValue(
+        XCTAssertEmitsValueEqualTo(
             from: sut.indexVisibilityPublisher,
+            expectedValue: false,
             afterTrigger: {
-                sut.searchText = ""
-                sut.searchFocusDidChange(isFocused: true)
+                self.sut.searchText = ""
+                self.sut.searchFocusDidChange(isFocused: true)
             }
         )
-
-        XCTAssertEqual(indexVisibilityPublisher, false)
     }
 
     func test_brands_index_hidden_with_unfocused_search_but_with_query() {
@@ -321,20 +274,16 @@ final class BrandsViewModelTests: XCTestCase {
             .mockBrands
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
-        let indexVisibilityPublisher = XCTAssertEmitsValue(
+        XCTAssertEmitsValueEqualTo(
             from: sut.indexVisibilityPublisher,
+            expectedValue: false,
             afterTrigger: {
-                sut.searchText = "query"
-                sut.searchFocusDidChange(isFocused: false)
+                self.sut.searchText = "query"
+                self.sut.searchFocusDidChange(isFocused: false)
             }
         )
-
-        XCTAssertEqual(indexVisibilityPublisher, false)
     }
 
     // MARK: - Placeholders

--- a/Alfie/AlfieTests/Features/BrandsViewModelTests.swift
+++ b/Alfie/AlfieTests/Features/BrandsViewModelTests.swift
@@ -32,9 +32,10 @@ final class BrandsViewModelTests: XCTestCase {
             []
         }
 
-       captureEvent(fromPublisher: sut.$state.eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertTrue(sut.state.didFail)
 
@@ -42,9 +43,10 @@ final class BrandsViewModelTests: XCTestCase {
             [.fixture(name: "Brand 1")]
         }
 
-       captureEvent(fromPublisher: sut.$state.eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertTrue(sut.state.isLoading)
     }
@@ -54,9 +56,10 @@ final class BrandsViewModelTests: XCTestCase {
             [.fixture(name: "Brand 1")]
         }
 
-       captureEvent(fromPublisher: sut.$state.eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertFalse(sut.state.isLoading)
         XCTAssertTrue(sut.state.isSuccess)
@@ -67,9 +70,10 @@ final class BrandsViewModelTests: XCTestCase {
             [Brand.fixture(name: "brand")]
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertTrue(sut.state.isSuccess)
     }
@@ -79,9 +83,10 @@ final class BrandsViewModelTests: XCTestCase {
             []
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertTrue(sut.state.didFail)
         XCTAssertEqual(sut.state.failure, .noResults)
@@ -92,9 +97,10 @@ final class BrandsViewModelTests: XCTestCase {
             throw BFFRequestError(type: .generic)
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertTrue(sut.state.didFail)
         XCTAssertEqual(sut.state.failure, .generic)
@@ -110,7 +116,7 @@ final class BrandsViewModelTests: XCTestCase {
         }
 
         sut.viewDidAppear()
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: `default`)
     }
 
     func test_ignores_load_brands_when_view_appears_but_brands_were_loaded_before() {
@@ -129,7 +135,7 @@ final class BrandsViewModelTests: XCTestCase {
             }
 
         sut.viewDidAppear()
-        wait(for: [firstExpectation, secondExpectation], timeout: defaultTimeout)
+        wait(for: [firstExpectation, secondExpectation], timeout: `default`)
 
         let thirdExpectation = expectation(description: "Wait for no service call")
         thirdExpectation.isInverted = true
@@ -139,7 +145,7 @@ final class BrandsViewModelTests: XCTestCase {
         }
 
         sut.viewDidAppear()
-        wait(for: [thirdExpectation], timeout: defaultTimeout)
+        wait(for: [thirdExpectation], timeout: inverted)
         cancellable.cancel()
     }
 
@@ -151,9 +157,10 @@ final class BrandsViewModelTests: XCTestCase {
             fixtures
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertEqual(sut.sectionTitles.count, 2)
         XCTAssertEqual(sut.state.value?.keys.count, sut.sectionTitles.count)
@@ -165,9 +172,10 @@ final class BrandsViewModelTests: XCTestCase {
             throw BFFRequestError(type: .generic)
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertTrue(sut.sectionTitles.isEmpty)
         XCTAssertTrue(sut.state.didFail)
@@ -179,9 +187,10 @@ final class BrandsViewModelTests: XCTestCase {
             fixtures
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         let expectedSections = OrderedSet(arrayLiteral: "A", "B", "C")
         XCTAssertEqual(sut.sectionTitles.count, 3)
@@ -199,9 +208,10 @@ final class BrandsViewModelTests: XCTestCase {
             fixtures
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertEqual(sut.brands(for: "A").count, 2)
         XCTAssertEqual(sut.brands(for: "B").count, 1)
@@ -216,9 +226,10 @@ final class BrandsViewModelTests: XCTestCase {
             .mockBrands
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertEqual(sut.sectionTitles, OrderedSet(arrayLiteral: "A", "B", "C"))
 
@@ -234,9 +245,10 @@ final class BrandsViewModelTests: XCTestCase {
             .mockBrands
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertEqual(sut.sectionTitles, OrderedSet(arrayLiteral: "A", "B", "C"))
 
@@ -250,9 +262,10 @@ final class BrandsViewModelTests: XCTestCase {
             .mockBrands
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         sut.searchText = "Alfie "
         XCTAssertEqual(sut.sectionTitles, OrderedSet(arrayLiteral: "A"))
@@ -266,14 +279,20 @@ final class BrandsViewModelTests: XCTestCase {
             .mockBrands
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
-        sut.searchText = ""
-        waitUntil(publisher: sut.indexVisibilityPublisher.eraseToAnyPublisher(), emitsValue: true, asyncOperation: {
-            self.sut.searchFocusDidChange(isFocused: false)
-        }, timeout: defaultTimeout)
+        let indexVisibilityPublisher = XCTAssertEmitsValue(
+            from: sut.indexVisibilityPublisher,
+            afterTrigger: {
+                sut.searchText = ""
+                sut.searchFocusDidChange(isFocused: false)
+            }
+        )
+
+        XCTAssertEqual(indexVisibilityPublisher, true)
     }
 
     func test_brands_index_hidden_with_focused_search_and_no_query() {
@@ -281,14 +300,20 @@ final class BrandsViewModelTests: XCTestCase {
             .mockBrands
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
-        sut.searchText = ""
-        waitUntil(publisher: sut.indexVisibilityPublisher.eraseToAnyPublisher(), emitsValue: false, asyncOperation: {
-            self.sut.searchFocusDidChange(isFocused: true)
-        }, timeout: defaultTimeout)
+        let indexVisibilityPublisher = XCTAssertEmitsValue(
+            from: sut.indexVisibilityPublisher,
+            afterTrigger: {
+                sut.searchText = ""
+                sut.searchFocusDidChange(isFocused: true)
+            }
+        )
+
+        XCTAssertEqual(indexVisibilityPublisher, false)
     }
 
     func test_brands_index_hidden_with_unfocused_search_but_with_query() {
@@ -296,14 +321,20 @@ final class BrandsViewModelTests: XCTestCase {
             .mockBrands
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
-        sut.searchText = "query"
-        waitUntil(publisher: sut.indexVisibilityPublisher.eraseToAnyPublisher(), emitsValue: false, asyncOperation: {
-            self.sut.searchFocusDidChange(isFocused: false)
-        }, timeout: defaultTimeout)
+        let indexVisibilityPublisher = XCTAssertEmitsValue(
+            from: sut.indexVisibilityPublisher,
+            afterTrigger: {
+                sut.searchText = "query"
+                sut.searchFocusDidChange(isFocused: false)
+            }
+        )
+
+        XCTAssertEqual(indexVisibilityPublisher, false)
     }
 
     // MARK: - Placeholders

--- a/Alfie/AlfieTests/Features/BrandsViewModelTests.swift
+++ b/Alfie/AlfieTests/Features/BrandsViewModelTests.swift
@@ -98,7 +98,7 @@ final class BrandsViewModelTests: XCTestCase {
         }
 
         sut.viewDidAppear()
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: .default)
     }
 
     func test_ignores_load_brands_when_view_appears_but_brands_were_loaded_before() {
@@ -117,7 +117,7 @@ final class BrandsViewModelTests: XCTestCase {
             }
 
         sut.viewDidAppear()
-        wait(for: [firstExpectation, secondExpectation])
+        wait(for: [firstExpectation, secondExpectation], timeout: .default)
 
         let thirdExpectation = expectation(description: "Wait for no service call")
         thirdExpectation.isInverted = true

--- a/Alfie/AlfieTests/Features/CategoriesViewModelTests.swift
+++ b/Alfie/AlfieTests/Features/CategoriesViewModelTests.swift
@@ -30,9 +30,10 @@ final class CategoriesViewModelTests: XCTestCase {
             []
         }
 
-       captureEvent(fromPublisher: sut.$state.eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertTrue(sut.state.didFail)
 
@@ -40,9 +41,10 @@ final class CategoriesViewModelTests: XCTestCase {
             NavigationItem.fixtures
         }
 
-       captureEvent(fromPublisher: sut.$state.eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertTrue(sut.state.isLoading)
     }
@@ -52,9 +54,10 @@ final class CategoriesViewModelTests: XCTestCase {
             NavigationItem.fixtures
         }
 
-       captureEvent(fromPublisher: sut.$state.eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertFalse(sut.state.isLoading)
         XCTAssertTrue(sut.state.isSuccess)
@@ -65,9 +68,10 @@ final class CategoriesViewModelTests: XCTestCase {
             NavigationItem.fixtures
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertTrue(sut.state.isSuccess)
     }
@@ -77,9 +81,10 @@ final class CategoriesViewModelTests: XCTestCase {
             []
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertTrue(sut.state.didFail)
         XCTAssertEqual(sut.state.failure, .noResults)
@@ -90,9 +95,10 @@ final class CategoriesViewModelTests: XCTestCase {
             throw BFFRequestError(type: .generic)
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertTrue(sut.state.didFail)
         XCTAssertEqual(sut.state.failure, .generic)
@@ -109,7 +115,7 @@ final class CategoriesViewModelTests: XCTestCase {
         }
 
         sut.viewDidAppear()
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: `default`)
     }
 
     func test_ignores_load_items_when_view_appears_but_items_were_loaded_before() {
@@ -129,7 +135,7 @@ final class CategoriesViewModelTests: XCTestCase {
             }
 
         sut.viewDidAppear()
-        wait(for: [firstExpectation, secondExpectation], timeout: defaultTimeout)
+        wait(for: [firstExpectation, secondExpectation], timeout: `default`)
 
         let thirdExpectation = expectation(description: "Wait for no service call")
         thirdExpectation.isInverted = true
@@ -140,7 +146,7 @@ final class CategoriesViewModelTests: XCTestCase {
         }
 
         sut.viewDidAppear()
-        wait(for: [thirdExpectation], timeout: defaultTimeout)
+        wait(for: [thirdExpectation], timeout: inverted)
         cancellable.cancel()
     }
 
@@ -155,7 +161,7 @@ final class CategoriesViewModelTests: XCTestCase {
         }
 
         sut.viewDidAppear()
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: inverted)
     }
 
     // MARK: - Categories
@@ -172,9 +178,10 @@ final class CategoriesViewModelTests: XCTestCase {
             return fixtures
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertEqual(sut.categories.count, fixtures.count)
     }
@@ -184,9 +191,10 @@ final class CategoriesViewModelTests: XCTestCase {
             throw BFFRequestError(type: .generic)
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertTrue(sut.categories.isEmpty)
     }
@@ -197,9 +205,10 @@ final class CategoriesViewModelTests: XCTestCase {
         let path = "/something"
         let fixture = NavigationItem.fixture(type: .page, url: path)
 
-        let destination = captureEvent(fromPublisher: sut.openCategoryPublisher, afterTrigger: {
-            sut.didSelectCategory(fixture)
-        })
+        let destination = XCTAssertEmitsValue(
+            from: sut.openCategoryPublisher,
+            afterTrigger: { sut.didSelectCategory(fixture) }
+        )
 
         guard let destination, case .web(let url, _) = destination else {
             XCTFail("Unexpected destination type: \(String(describing: destination))")
@@ -214,9 +223,10 @@ final class CategoriesViewModelTests: XCTestCase {
         let itemTitle = "Something"
         let fixture = NavigationItem.fixture(type: .page, title: itemTitle, url: path)
 
-        let destination = captureEvent(fromPublisher: sut.openCategoryPublisher, afterTrigger: {
-            sut.didSelectCategory(fixture)
-        })
+        let destination = XCTAssertEmitsValue(
+            from: sut.openCategoryPublisher,
+            afterTrigger: { sut.didSelectCategory(fixture) }
+        )
 
         guard let destination, case .web(let url, let title) = destination else {
             XCTFail("Unexpected destination type: \(String(describing: destination))")
@@ -231,9 +241,10 @@ final class CategoriesViewModelTests: XCTestCase {
         let path = "/clothing"
         let fixture = NavigationItem.fixture(type: .listing, url: path)
 
-        let destination = captureEvent(fromPublisher: sut.openCategoryPublisher, afterTrigger: {
-            sut.didSelectCategory(fixture)
-        })
+        let destination = XCTAssertEmitsValue(
+            from: sut.openCategoryPublisher,
+            afterTrigger: { sut.didSelectCategory(fixture) }
+        )
 
         guard let destination, case .plp(let category) = destination else {
             XCTFail("Unexpected destination type: \(String(describing: destination))")
@@ -246,9 +257,10 @@ final class CategoriesViewModelTests: XCTestCase {
     func test_sets_error_state_when_category_with_invalid_url_is_selected() {
         let fixture = NavigationItem.fixture(url: nil)
 
-       captureEvent(fromPublisher: sut.$state.eraseToAnyPublisher(), afterTrigger: {
-            sut.didSelectCategory(fixture)
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            afterTrigger: { sut.didSelectCategory(fixture) }
+        )
 
         XCTAssertTrue(sut.state.didFail)
         XCTAssertEqual(sut.state.failure, .generic)
@@ -260,9 +272,10 @@ final class CategoriesViewModelTests: XCTestCase {
         let subFixtures = NavigationItem.fixtures
         let fixture = NavigationItem.fixture(title: parentTitle, items: subFixtures)
 
-        let destination = captureEvent(fromPublisher: sut.openCategoryPublisher, afterTrigger: {
-            sut.didSelectCategory(fixture)
-        })
+        let destination = XCTAssertEmitsValue(
+            from: sut.openCategoryPublisher,
+            afterTrigger: { sut.didSelectCategory(fixture) }
+        )
 
         guard let destination, case .subCategories(let subCategories, let parentCategory) = destination else {
             XCTFail("Unexpected destination type: \(String(describing: destination))")
@@ -274,12 +287,12 @@ final class CategoriesViewModelTests: XCTestCase {
     }
 
     func test_triggers_navigation_when_special_services_category_is_selected() {
-        let fixture = NavigationItem.fixture(type: .page,
-                                             url: "/store-services")
+        let fixture = NavigationItem.fixture(type: .page, url: "/store-services")
 
-        let destination = captureEvent(fromPublisher: sut.openCategoryPublisher, afterTrigger: {
-            sut.didSelectCategory(fixture)
-        })
+        let destination = XCTAssertEmitsValue(
+            from: sut.openCategoryPublisher,
+            afterTrigger: { sut.didSelectCategory(fixture) }
+        )
 
         guard let destination else {
             XCTFail("Unexpected nil destination")
@@ -296,12 +309,12 @@ final class CategoriesViewModelTests: XCTestCase {
     }
 
     func test_triggers_navigation_when_special_brands_category_is_selected() {
-        let fixture = NavigationItem.fixture(type: .page,
-                                             url: "/brands")
+        let fixture = NavigationItem.fixture(type: .page, url: "/brands")
 
-        let destination = captureEvent(fromPublisher: sut.openCategoryPublisher, afterTrigger: {
-            sut.didSelectCategory(fixture)
-        })
+        let destination = XCTAssertEmitsValue(
+            from: sut.openCategoryPublisher,
+            afterTrigger: { sut.didSelectCategory(fixture) }
+        )
 
         guard let destination else {
             XCTFail("Unexpected nil destination")

--- a/Alfie/AlfieTests/Features/CategoriesViewModelTests.swift
+++ b/Alfie/AlfieTests/Features/CategoriesViewModelTests.swift
@@ -97,7 +97,7 @@ final class CategoriesViewModelTests: XCTestCase {
         }
 
         sut.viewDidAppear()
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: .default)
     }
 
     func test_ignores_load_items_when_view_appears_but_items_were_loaded_before() {
@@ -117,7 +117,7 @@ final class CategoriesViewModelTests: XCTestCase {
             }
 
         sut.viewDidAppear()
-        wait(for: [firstExpectation, secondExpectation])
+        wait(for: [firstExpectation, secondExpectation], timeout: .default)
 
         let thirdExpectation = expectation(description: "Wait for no service call")
         thirdExpectation.isInverted = true

--- a/Alfie/AlfieTests/Features/CategoriesViewModelTests.swift
+++ b/Alfie/AlfieTests/Features/CategoriesViewModelTests.swift
@@ -30,10 +30,7 @@ final class CategoriesViewModelTests: XCTestCase {
             []
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state,
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state, afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertTrue(sut.state.didFail)
 
@@ -41,10 +38,7 @@ final class CategoriesViewModelTests: XCTestCase {
             NavigationItem.fixtures
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state,
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state, afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertTrue(sut.state.isLoading)
     }
@@ -54,10 +48,7 @@ final class CategoriesViewModelTests: XCTestCase {
             NavigationItem.fixtures
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state,
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state, afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertFalse(sut.state.isLoading)
         XCTAssertTrue(sut.state.isSuccess)
@@ -68,10 +59,7 @@ final class CategoriesViewModelTests: XCTestCase {
             NavigationItem.fixtures
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertTrue(sut.state.isSuccess)
     }
@@ -81,10 +69,7 @@ final class CategoriesViewModelTests: XCTestCase {
             []
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertTrue(sut.state.didFail)
         XCTAssertEqual(sut.state.failure, .noResults)
@@ -95,10 +80,7 @@ final class CategoriesViewModelTests: XCTestCase {
             throw BFFRequestError(type: .generic)
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertTrue(sut.state.didFail)
         XCTAssertEqual(sut.state.failure, .generic)
@@ -115,7 +97,7 @@ final class CategoriesViewModelTests: XCTestCase {
         }
 
         sut.viewDidAppear()
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
     }
 
     func test_ignores_load_items_when_view_appears_but_items_were_loaded_before() {
@@ -135,7 +117,7 @@ final class CategoriesViewModelTests: XCTestCase {
             }
 
         sut.viewDidAppear()
-        wait(for: [firstExpectation, secondExpectation], timeout: `default`)
+        wait(for: [firstExpectation, secondExpectation])
 
         let thirdExpectation = expectation(description: "Wait for no service call")
         thirdExpectation.isInverted = true
@@ -146,7 +128,7 @@ final class CategoriesViewModelTests: XCTestCase {
         }
 
         sut.viewDidAppear()
-        wait(for: [thirdExpectation], timeout: inverted)
+        wait(for: [thirdExpectation], timeout: .inverted)
         cancellable.cancel()
     }
 
@@ -161,7 +143,7 @@ final class CategoriesViewModelTests: XCTestCase {
         }
 
         sut.viewDidAppear()
-        wait(for: [expectation], timeout: inverted)
+        wait(for: [expectation], timeout: .inverted)
     }
 
     // MARK: - Categories
@@ -178,10 +160,7 @@ final class CategoriesViewModelTests: XCTestCase {
             return fixtures
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertEqual(sut.categories.count, fixtures.count)
     }
@@ -191,10 +170,7 @@ final class CategoriesViewModelTests: XCTestCase {
             throw BFFRequestError(type: .generic)
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertTrue(sut.categories.isEmpty)
     }
@@ -207,7 +183,7 @@ final class CategoriesViewModelTests: XCTestCase {
 
         let destination = XCTAssertEmitsValue(
             from: sut.openCategoryPublisher,
-            afterTrigger: { sut.didSelectCategory(fixture) }
+            afterTrigger: { self.sut.didSelectCategory(fixture) }
         )
 
         guard let destination, case .web(let url, _) = destination else {
@@ -225,7 +201,7 @@ final class CategoriesViewModelTests: XCTestCase {
 
         let destination = XCTAssertEmitsValue(
             from: sut.openCategoryPublisher,
-            afterTrigger: { sut.didSelectCategory(fixture) }
+            afterTrigger: { self.sut.didSelectCategory(fixture) }
         )
 
         guard let destination, case .web(let url, let title) = destination else {
@@ -243,7 +219,7 @@ final class CategoriesViewModelTests: XCTestCase {
 
         let destination = XCTAssertEmitsValue(
             from: sut.openCategoryPublisher,
-            afterTrigger: { sut.didSelectCategory(fixture) }
+            afterTrigger: { self.sut.didSelectCategory(fixture) }
         )
 
         guard let destination, case .plp(let category) = destination else {
@@ -257,10 +233,7 @@ final class CategoriesViewModelTests: XCTestCase {
     func test_sets_error_state_when_category_with_invalid_url_is_selected() {
         let fixture = NavigationItem.fixture(url: nil)
 
-        XCTAssertEmitsValue(
-            from: sut.$state,
-            afterTrigger: { sut.didSelectCategory(fixture) }
-        )
+        XCTAssertEmitsValue(from: sut.$state, afterTrigger: { self.sut.didSelectCategory(fixture) })
 
         XCTAssertTrue(sut.state.didFail)
         XCTAssertEqual(sut.state.failure, .generic)
@@ -274,7 +247,7 @@ final class CategoriesViewModelTests: XCTestCase {
 
         let destination = XCTAssertEmitsValue(
             from: sut.openCategoryPublisher,
-            afterTrigger: { sut.didSelectCategory(fixture) }
+            afterTrigger: { self.sut.didSelectCategory(fixture) }
         )
 
         guard let destination, case .subCategories(let subCategories, let parentCategory) = destination else {
@@ -291,7 +264,7 @@ final class CategoriesViewModelTests: XCTestCase {
 
         let destination = XCTAssertEmitsValue(
             from: sut.openCategoryPublisher,
-            afterTrigger: { sut.didSelectCategory(fixture) }
+            afterTrigger: { self.sut.didSelectCategory(fixture) }
         )
 
         guard let destination else {
@@ -313,7 +286,7 @@ final class CategoriesViewModelTests: XCTestCase {
 
         let destination = XCTAssertEmitsValue(
             from: sut.openCategoryPublisher,
-            afterTrigger: { sut.didSelectCategory(fixture) }
+            afterTrigger: { self.sut.didSelectCategory(fixture) }
         )
 
         guard let destination else {

--- a/Alfie/AlfieTests/Features/EndpointSelectionViewModelTests.swift
+++ b/Alfie/AlfieTests/Features/EndpointSelectionViewModelTests.swift
@@ -166,7 +166,7 @@ final class EndpointSelectionViewModelTests: XCTestCase {
         sut = .init(apiEndpointService: mockEndpointService)
         sut.selectedEndpointOption = .preProd
         sut.didTapSave()
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: `default`)
     }
 
     func test_saves_selected_custom_option_with_url_on_service() {
@@ -182,6 +182,6 @@ final class EndpointSelectionViewModelTests: XCTestCase {
         sut.selectedEndpointOption = .custom(url: nil)
         sut.customEndpointUrl = urlString
         sut.didTapSave()
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: `default`)
     }
 }

--- a/Alfie/AlfieTests/Features/EndpointSelectionViewModelTests.swift
+++ b/Alfie/AlfieTests/Features/EndpointSelectionViewModelTests.swift
@@ -166,7 +166,7 @@ final class EndpointSelectionViewModelTests: XCTestCase {
         sut = .init(apiEndpointService: mockEndpointService)
         sut.selectedEndpointOption = .preProd
         sut.didTapSave()
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
     }
 
     func test_saves_selected_custom_option_with_url_on_service() {
@@ -182,6 +182,6 @@ final class EndpointSelectionViewModelTests: XCTestCase {
         sut.selectedEndpointOption = .custom(url: nil)
         sut.customEndpointUrl = urlString
         sut.didTapSave()
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
     }
 }

--- a/Alfie/AlfieTests/Features/EndpointSelectionViewModelTests.swift
+++ b/Alfie/AlfieTests/Features/EndpointSelectionViewModelTests.swift
@@ -166,7 +166,7 @@ final class EndpointSelectionViewModelTests: XCTestCase {
         sut = .init(apiEndpointService: mockEndpointService)
         sut.selectedEndpointOption = .preProd
         sut.didTapSave()
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: .default)
     }
 
     func test_saves_selected_custom_option_with_url_on_service() {
@@ -182,6 +182,6 @@ final class EndpointSelectionViewModelTests: XCTestCase {
         sut.selectedEndpointOption = .custom(url: nil)
         sut.customEndpointUrl = urlString
         sut.didTapSave()
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: .default)
     }
 }

--- a/Alfie/AlfieTests/Features/ProductDetailsViewModelTests.swift
+++ b/Alfie/AlfieTests/Features/ProductDetailsViewModelTests.swift
@@ -15,6 +15,7 @@ final class ProductDetailsViewModelTests: XCTestCase {
         mockProductService = MockProductService()
         mockWebUrlProvider = MockWebUrlProvider()
         mockDependencies = ProductDetailsDependencyContainer(
+            scheduler: .immediate,
             productService: mockProductService,
             webUrlProvider: mockWebUrlProvider,
             bagService: MockBagService(),
@@ -96,9 +97,10 @@ final class ProductDetailsViewModelTests: XCTestCase {
         let product = Product.fixture(brand: .fixture(name: "Product Brand"))
         initViewModel(product: product)
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertEqual(sut.productTitle, product.brand.name)
     }
@@ -112,9 +114,10 @@ final class ProductDetailsViewModelTests: XCTestCase {
         let product = Product.fixture(name: "Product Name")
         initViewModel(product: product)
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertEqual(sut.productName, product.name)
     }
@@ -130,14 +133,13 @@ final class ProductDetailsViewModelTests: XCTestCase {
             .image(.fixture(url: URL(string: "http://some.media.url.2")!)),
         ])
         let variant = Product.Variant.fixture(colour: color)
-        let product = Product.fixture(name: "Product Name",
-                                      defaultVariant: variant,
-                                      variants: [variant])
+        let product = Product.fixture(name: "Product Name", defaultVariant: variant, variants: [variant])
         initViewModel(product: product)
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertEqual(sut.productImageUrls.count, variant.media.count)
         XCTAssertEqual(sut.productImageUrls[0].absoluteString, variant.media[0].asImage?.url.absoluteString)
@@ -162,9 +164,10 @@ final class ProductDetailsViewModelTests: XCTestCase {
         let product = Product.fixture(longDescription: "Product Description")
         initViewModel(product: product)
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertEqual(sut.productDescription, product.longDescription)
     }
@@ -218,7 +221,7 @@ final class ProductDetailsViewModelTests: XCTestCase {
         }
 
         sut.viewDidAppear()
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: `default`)
     }
 
     func test_product_is_not_fetched_when_view_appears_if_already_fetched() {
@@ -241,7 +244,7 @@ final class ProductDetailsViewModelTests: XCTestCase {
             }
 
         sut.viewDidAppear()
-        wait(for: [firstExpectation, secondExpectation], timeout: defaultTimeout)
+        wait(for: [firstExpectation, secondExpectation], timeout: `default`)
 
         let thirdExpectation = expectation(description: "Wait for no service call")
         thirdExpectation.isInverted = true
@@ -251,7 +254,7 @@ final class ProductDetailsViewModelTests: XCTestCase {
         }
 
         sut.viewDidAppear()
-        wait(for: [thirdExpectation], timeout: defaultTimeout)
+        wait(for: [thirdExpectation], timeout: inverted)
         cancellable.cancel()
     }
 
@@ -262,9 +265,10 @@ final class ProductDetailsViewModelTests: XCTestCase {
             .fixture()
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertTrue(sut.state.isSuccess)
     }
@@ -276,9 +280,10 @@ final class ProductDetailsViewModelTests: XCTestCase {
             throw BFFRequestError(type: .generic)
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertTrue(sut.state.didFail)
         XCTAssertEqual(sut.state.failure, .generic)
@@ -291,9 +296,10 @@ final class ProductDetailsViewModelTests: XCTestCase {
             throw BFFRequestError(type: .emptyResponse)
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertTrue(sut.state.didFail)
         XCTAssertEqual(sut.state.failure, .notFound)
@@ -316,9 +322,10 @@ final class ProductDetailsViewModelTests: XCTestCase {
             product
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         let selectedVariant = sut.state.value?.selectedVariant
         XCTAssertNotNil(selectedVariant)
@@ -339,9 +346,10 @@ final class ProductDetailsViewModelTests: XCTestCase {
     func test_state_is_loading_when_fetching_product() {
         initViewModel()
 
-        let state = captureEvent(fromPublisher: sut.$state.eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        let state = XCTAssertEmitsValue(
+            from: sut.$state,
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertEqual(state?.isLoading, true)
     }
@@ -368,9 +376,10 @@ final class ProductDetailsViewModelTests: XCTestCase {
             .fixture()
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         let result = sut.shouldShowLoading(for: .titleHeader)
         XCTAssertFalse(result)
@@ -390,9 +399,10 @@ final class ProductDetailsViewModelTests: XCTestCase {
             .fixture()
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         let result = sut.shouldShowLoading(for: .colorSelector)
         XCTAssertFalse(result)
@@ -412,9 +422,10 @@ final class ProductDetailsViewModelTests: XCTestCase {
             .fixture()
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         let result = sut.shouldShowLoading(for: .sizeSelector)
         XCTAssertFalse(result)
@@ -434,9 +445,10 @@ final class ProductDetailsViewModelTests: XCTestCase {
             .fixture()
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         let result = sut.shouldShowLoading(for: .mediaCarousel)
         XCTAssertFalse(result)
@@ -456,9 +468,10 @@ final class ProductDetailsViewModelTests: XCTestCase {
             .fixture()
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         let result = sut.shouldShowLoading(for: .complementaryInfo)
         XCTAssertFalse(result)
@@ -478,9 +491,10 @@ final class ProductDetailsViewModelTests: XCTestCase {
             .fixture()
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         let result = sut.shouldShowLoading(for: .productDescription)
         XCTAssertFalse(result)
@@ -500,9 +514,10 @@ final class ProductDetailsViewModelTests: XCTestCase {
             product
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         let colorSelectionConfiguration = sut.colorSelectionConfiguration
         XCTAssertEqual(colorSelectionConfiguration.items.count, 1)
@@ -527,9 +542,10 @@ final class ProductDetailsViewModelTests: XCTestCase {
             product
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         let colorSelectionConfiguration = sut.colorSelectionConfiguration
         XCTAssertEqual(colorSelectionConfiguration.items.first?.type, .color(.black))
@@ -550,14 +566,16 @@ final class ProductDetailsViewModelTests: XCTestCase {
             product
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         let colorSelectionConfiguration = sut.colorSelectionConfiguration
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            colorSelectionConfiguration.selectedItem = colorSelectionConfiguration.items[1]
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { colorSelectionConfiguration.selectedItem = colorSelectionConfiguration.items[1] }
+        )
 
         let selectedVariant = sut.state.value?.selectedVariant
         XCTAssertNotNil(selectedVariant)
@@ -581,12 +599,17 @@ final class ProductDetailsViewModelTests: XCTestCase {
             product
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         let colorSelectionConfiguration = sut.colorSelectionConfiguration
-        let result = assertNoEvent(from: sut.$state.eraseToAnyPublisher(), afterTrigger: { colorSelectionConfiguration.selectedItem = nil }, timeout: defaultTimeout)
+        let result = XCTAssertNoEmit(
+            from: sut.$state,
+            afterTrigger: { colorSelectionConfiguration.selectedItem = nil },
+            timeout: inverted
+        )
         XCTAssertTrue(result)
     }
 
@@ -605,12 +628,17 @@ final class ProductDetailsViewModelTests: XCTestCase {
             product
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         let colorSelectionConfiguration = sut.colorSelectionConfiguration
-        let result = assertNoEvent(from: sut.$state.eraseToAnyPublisher(), afterTrigger: { colorSelectionConfiguration.selectedItem = ColorSwatch(id: "3", name: "Color 3", type: .color(.black)) }, timeout: defaultTimeout)
+        let result = XCTAssertNoEmit(
+            from: sut.$state,
+            afterTrigger: { colorSelectionConfiguration.selectedItem = ColorSwatch(id: "3", name: "Color 3", type: .color(.black)) },
+            timeout: inverted
+        )
         XCTAssertTrue(result)
     }
 
@@ -634,14 +662,16 @@ final class ProductDetailsViewModelTests: XCTestCase {
             product
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         let colorSelectionConfiguration = sut.colorSelectionConfiguration
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            colorSelectionConfiguration.selectedItem = colorSelectionConfiguration.items[1]
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { colorSelectionConfiguration.selectedItem = colorSelectionConfiguration.items[1] }
+        )
 
         XCTAssertEqual(sut.productImageUrls.count, variant2.media.count)
         XCTAssertEqual(sut.productImageUrls[0].absoluteString, variant2.media[0].asImage?.url.absoluteString)
@@ -712,9 +742,10 @@ final class ProductDetailsViewModelTests: XCTestCase {
             product
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertTrue(sut.shouldShow(section: .mediaCarousel))
     }
@@ -730,9 +761,10 @@ final class ProductDetailsViewModelTests: XCTestCase {
             product
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertFalse(sut.shouldShow(section: .mediaCarousel))
     }
@@ -745,9 +777,10 @@ final class ProductDetailsViewModelTests: XCTestCase {
             product
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertTrue(sut.shouldShow(section: .productDescription))
     }
@@ -760,9 +793,10 @@ final class ProductDetailsViewModelTests: XCTestCase {
             product
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertFalse(sut.shouldShow(section: .productDescription))
     }
@@ -775,9 +809,10 @@ final class ProductDetailsViewModelTests: XCTestCase {
             product
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertTrue(sut.shouldShow(section: .addToBag))
     }
@@ -789,9 +824,10 @@ final class ProductDetailsViewModelTests: XCTestCase {
             throw BFFRequestError(type: .generic)
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertFalse(sut.shouldShow(section: .addToBag))
     }
@@ -817,9 +853,10 @@ final class ProductDetailsViewModelTests: XCTestCase {
             throw BFFRequestError(type: .generic)
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertNil(sut.shareConfiguration)
     }
@@ -844,9 +881,10 @@ final class ProductDetailsViewModelTests: XCTestCase {
             return URL(string: urlString)
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0.isLoading }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0.isLoading }),
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         let shareConfiguration = sut.shareConfiguration
         XCTAssertNotNil(shareConfiguration)
@@ -864,7 +902,6 @@ final class ProductDetailsViewModelTests: XCTestCase {
                                       variants: (expectedMatchedColors + expectedNonMatchedColors).map { Product.Variant.fixture(colour: $0) })
 
         initViewModel(product: product)
-        let allSwatches = sut.colorSelectionConfiguration.items
         let swatchesSearchResult = sut.colorSwatches(filteredBy: "Col")
         XCTAssertTrue(swatchesSearchResult.map(\.name).contains(expectedMatchedColors.map(\.name)))
         XCTAssertFalse(swatchesSearchResult.map(\.name).contains(expectedNonMatchedColors.map(\.name)))

--- a/Alfie/AlfieTests/Features/ProductDetailsViewModelTests.swift
+++ b/Alfie/AlfieTests/Features/ProductDetailsViewModelTests.swift
@@ -209,7 +209,7 @@ final class ProductDetailsViewModelTests: XCTestCase {
         }
 
         sut.viewDidAppear()
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: .default)
     }
 
     func test_product_is_not_fetched_when_view_appears_if_already_fetched() {
@@ -232,7 +232,7 @@ final class ProductDetailsViewModelTests: XCTestCase {
             }
 
         sut.viewDidAppear()
-        wait(for: [firstExpectation, secondExpectation])
+        wait(for: [firstExpectation, secondExpectation], timeout: .default)
 
         let thirdExpectation = expectation(description: "Wait for no service call")
         thirdExpectation.isInverted = true

--- a/Alfie/AlfieTests/Features/ProductDetailsViewModelTests.swift
+++ b/Alfie/AlfieTests/Features/ProductDetailsViewModelTests.swift
@@ -97,10 +97,7 @@ final class ProductDetailsViewModelTests: XCTestCase {
         let product = Product.fixture(brand: .fixture(name: "Product Brand"))
         initViewModel(product: product)
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertEqual(sut.productTitle, product.brand.name)
     }
@@ -114,10 +111,7 @@ final class ProductDetailsViewModelTests: XCTestCase {
         let product = Product.fixture(name: "Product Name")
         initViewModel(product: product)
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertEqual(sut.productName, product.name)
     }
@@ -136,10 +130,7 @@ final class ProductDetailsViewModelTests: XCTestCase {
         let product = Product.fixture(name: "Product Name", defaultVariant: variant, variants: [variant])
         initViewModel(product: product)
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertEqual(sut.productImageUrls.count, variant.media.count)
         XCTAssertEqual(sut.productImageUrls[0].absoluteString, variant.media[0].asImage?.url.absoluteString)
@@ -164,10 +155,7 @@ final class ProductDetailsViewModelTests: XCTestCase {
         let product = Product.fixture(longDescription: "Product Description")
         initViewModel(product: product)
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertEqual(sut.productDescription, product.longDescription)
     }
@@ -221,7 +209,7 @@ final class ProductDetailsViewModelTests: XCTestCase {
         }
 
         sut.viewDidAppear()
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
     }
 
     func test_product_is_not_fetched_when_view_appears_if_already_fetched() {
@@ -244,7 +232,7 @@ final class ProductDetailsViewModelTests: XCTestCase {
             }
 
         sut.viewDidAppear()
-        wait(for: [firstExpectation, secondExpectation], timeout: `default`)
+        wait(for: [firstExpectation, secondExpectation])
 
         let thirdExpectation = expectation(description: "Wait for no service call")
         thirdExpectation.isInverted = true
@@ -254,7 +242,7 @@ final class ProductDetailsViewModelTests: XCTestCase {
         }
 
         sut.viewDidAppear()
-        wait(for: [thirdExpectation], timeout: inverted)
+        wait(for: [thirdExpectation], timeout: .inverted)
         cancellable.cancel()
     }
 
@@ -265,10 +253,7 @@ final class ProductDetailsViewModelTests: XCTestCase {
             .fixture()
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertTrue(sut.state.isSuccess)
     }
@@ -280,10 +265,7 @@ final class ProductDetailsViewModelTests: XCTestCase {
             throw BFFRequestError(type: .generic)
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertTrue(sut.state.didFail)
         XCTAssertEqual(sut.state.failure, .generic)
@@ -296,10 +278,7 @@ final class ProductDetailsViewModelTests: XCTestCase {
             throw BFFRequestError(type: .emptyResponse)
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertTrue(sut.state.didFail)
         XCTAssertEqual(sut.state.failure, .notFound)
@@ -322,10 +301,7 @@ final class ProductDetailsViewModelTests: XCTestCase {
             product
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         let selectedVariant = sut.state.value?.selectedVariant
         XCTAssertNotNil(selectedVariant)
@@ -346,10 +322,7 @@ final class ProductDetailsViewModelTests: XCTestCase {
     func test_state_is_loading_when_fetching_product() {
         initViewModel()
 
-        let state = XCTAssertEmitsValue(
-            from: sut.$state,
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        let state = XCTAssertEmitsValue(from: sut.$state, afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertEqual(state?.isLoading, true)
     }
@@ -376,10 +349,7 @@ final class ProductDetailsViewModelTests: XCTestCase {
             .fixture()
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         let result = sut.shouldShowLoading(for: .titleHeader)
         XCTAssertFalse(result)
@@ -399,10 +369,7 @@ final class ProductDetailsViewModelTests: XCTestCase {
             .fixture()
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         let result = sut.shouldShowLoading(for: .colorSelector)
         XCTAssertFalse(result)
@@ -422,10 +389,7 @@ final class ProductDetailsViewModelTests: XCTestCase {
             .fixture()
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         let result = sut.shouldShowLoading(for: .sizeSelector)
         XCTAssertFalse(result)
@@ -445,10 +409,7 @@ final class ProductDetailsViewModelTests: XCTestCase {
             .fixture()
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         let result = sut.shouldShowLoading(for: .mediaCarousel)
         XCTAssertFalse(result)
@@ -468,10 +429,7 @@ final class ProductDetailsViewModelTests: XCTestCase {
             .fixture()
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         let result = sut.shouldShowLoading(for: .complementaryInfo)
         XCTAssertFalse(result)
@@ -491,10 +449,7 @@ final class ProductDetailsViewModelTests: XCTestCase {
             .fixture()
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         let result = sut.shouldShowLoading(for: .productDescription)
         XCTAssertFalse(result)
@@ -514,10 +469,7 @@ final class ProductDetailsViewModelTests: XCTestCase {
             product
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         let colorSelectionConfiguration = sut.colorSelectionConfiguration
         XCTAssertEqual(colorSelectionConfiguration.items.count, 1)
@@ -542,10 +494,7 @@ final class ProductDetailsViewModelTests: XCTestCase {
             product
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         let colorSelectionConfiguration = sut.colorSelectionConfiguration
         XCTAssertEqual(colorSelectionConfiguration.items.first?.type, .color(.black))
@@ -566,14 +515,11 @@ final class ProductDetailsViewModelTests: XCTestCase {
             product
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         let colorSelectionConfiguration = sut.colorSelectionConfiguration
         XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
+            from: sut.$state.drop(while: \.isLoading),
             afterTrigger: { colorSelectionConfiguration.selectedItem = colorSelectionConfiguration.items[1] }
         )
 
@@ -599,18 +545,10 @@ final class ProductDetailsViewModelTests: XCTestCase {
             product
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         let colorSelectionConfiguration = sut.colorSelectionConfiguration
-        let result = XCTAssertNoEmit(
-            from: sut.$state,
-            afterTrigger: { colorSelectionConfiguration.selectedItem = nil },
-            timeout: inverted
-        )
-        XCTAssertTrue(result)
+        XCTAssertNoEmit(from: sut.$state, afterTrigger: { colorSelectionConfiguration.selectedItem = nil })
     }
 
     func test_state_is_not_updated_if_unknown_color_is_selected() {
@@ -628,18 +566,13 @@ final class ProductDetailsViewModelTests: XCTestCase {
             product
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         let colorSelectionConfiguration = sut.colorSelectionConfiguration
-        let result = XCTAssertNoEmit(
+        XCTAssertNoEmit(
             from: sut.$state,
-            afterTrigger: { colorSelectionConfiguration.selectedItem = ColorSwatch(id: "3", name: "Color 3", type: .color(.black)) },
-            timeout: inverted
+            afterTrigger: { colorSelectionConfiguration.selectedItem = ColorSwatch(id: "3", name: "Color 3", type: .color(.black)) }
         )
-        XCTAssertTrue(result)
     }
 
     func test_product_images_are_updated_when_color_is_selected() {
@@ -662,14 +595,11 @@ final class ProductDetailsViewModelTests: XCTestCase {
             product
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         let colorSelectionConfiguration = sut.colorSelectionConfiguration
         XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
+            from: sut.$state.drop(while: \.isLoading),
             afterTrigger: { colorSelectionConfiguration.selectedItem = colorSelectionConfiguration.items[1] }
         )
 
@@ -742,10 +672,7 @@ final class ProductDetailsViewModelTests: XCTestCase {
             product
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertTrue(sut.shouldShow(section: .mediaCarousel))
     }
@@ -761,10 +688,7 @@ final class ProductDetailsViewModelTests: XCTestCase {
             product
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertFalse(sut.shouldShow(section: .mediaCarousel))
     }
@@ -777,10 +701,7 @@ final class ProductDetailsViewModelTests: XCTestCase {
             product
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertTrue(sut.shouldShow(section: .productDescription))
     }
@@ -793,10 +714,7 @@ final class ProductDetailsViewModelTests: XCTestCase {
             product
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertFalse(sut.shouldShow(section: .productDescription))
     }
@@ -809,10 +727,7 @@ final class ProductDetailsViewModelTests: XCTestCase {
             product
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertTrue(sut.shouldShow(section: .addToBag))
     }
@@ -824,10 +739,7 @@ final class ProductDetailsViewModelTests: XCTestCase {
             throw BFFRequestError(type: .generic)
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertFalse(sut.shouldShow(section: .addToBag))
     }
@@ -853,10 +765,7 @@ final class ProductDetailsViewModelTests: XCTestCase {
             throw BFFRequestError(type: .generic)
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertNil(sut.shareConfiguration)
     }
@@ -881,10 +790,7 @@ final class ProductDetailsViewModelTests: XCTestCase {
             return URL(string: urlString)
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state.drop(while: { $0.isLoading }),
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state.drop(while: \.isLoading), afterTrigger: { self.sut.viewDidAppear() })
 
         let shareConfiguration = sut.shareConfiguration
         XCTAssertNotNil(shareConfiguration)

--- a/Alfie/AlfieTests/Features/ProductListingViewModelTests.swift
+++ b/Alfie/AlfieTests/Features/ProductListingViewModelTests.swift
@@ -73,9 +73,10 @@ final class ProductListingViewModelTests: XCTestCase {
                                           products: Array(Product.fixtures.prefix(5)))
         }
 
-       captureEvent(fromPublisher: sut.$state.eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertTrue(sut.state.isSuccess)
         XCTAssertEqual(sut.title, "Women's Clothing")
@@ -107,9 +108,10 @@ final class ProductListingViewModelTests: XCTestCase {
                                           products: Array(Product.fixtures.prefix(5)))
         }
 
-       captureEvent(fromPublisher: sut.$state.eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertTrue(sut.state.isSuccess)
         XCTAssertEqual(sut.title, "Women's Clothing")
@@ -121,9 +123,10 @@ final class ProductListingViewModelTests: XCTestCase {
             throw BFFRequestError(type: .product(.noProducts(category: categoryId, query: query, sort: sort)))
         }
 
-       captureEvent(fromPublisher: sut.$state.eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertTrue(sut.state.didFail)
         XCTAssertEqual(sut.state.failure, .generic)
@@ -155,15 +158,17 @@ final class ProductListingViewModelTests: XCTestCase {
             return ProductListing.fixture(products: Product.fixtures)
         }
 
-       captureEvent(fromPublisher: sut.$state.eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertTrue(sut.state.isSuccess)
 
-       captureEvent(fromPublisher: sut.$state.eraseToAnyPublisher(), afterTrigger: {
-            sut.didDisplay(Product.fixtures.last!)
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            afterTrigger: { sut.didDisplay(Product.fixtures.last!) }
+        )
 
         XCTAssertTrue(sut.state.isLoadingNextPage)
     }
@@ -174,9 +179,11 @@ final class ProductListingViewModelTests: XCTestCase {
             ProductListing.fixture(products: Product.fixtures)
         }
 
-        _ = assertNoEvent(from: sut.$state.eraseToAnyPublisher(), afterTrigger: {
-            sut.didDisplay(Product.fixtures.last!)
-        })
+        XCTAssertNoEmit(
+            from: sut.$state,
+            afterTrigger: { sut.didDisplay(Product.fixtures.last!) },
+            timeout: inverted
+        )
     }
 
     func test_does_not_fetch_next_page_while_displaying_products() {
@@ -188,9 +195,11 @@ final class ProductListingViewModelTests: XCTestCase {
             ProductListing.fixture(products: Product.fixtures)
         }
 
-        _ = assertNoEvent(from: sut.$state.eraseToAnyPublisher(), afterTrigger: {
-            sut.didDisplay(penultimateProduct)
-        })
+        XCTAssertNoEmit(
+            from: sut.$state,
+            afterTrigger: { sut.didDisplay(penultimateProduct) },
+            timeout: inverted
+        )
     }
 
     func test_allows_showing_search_if_not_loading_and_not_showing_search_results() {
@@ -216,9 +225,10 @@ final class ProductListingViewModelTests: XCTestCase {
                                           products: Array(Product.fixtures.prefix(5)))
         }
 
-       captureEvent(fromPublisher: sut.$state.eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertTrue(sut.state.isSuccess)
         XCTAssertTrue(sut.showSearchButton)
@@ -265,9 +275,10 @@ final class ProductListingViewModelTests: XCTestCase {
                                           products: Array(Product.fixtures.prefix(5)))
         }
 
-       captureEvent(fromPublisher: sut.$state.eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertTrue(sut.state.isSuccess)
         XCTAssertFalse(sut.showSearchButton)

--- a/Alfie/AlfieTests/Features/ProductListingViewModelTests.swift
+++ b/Alfie/AlfieTests/Features/ProductListingViewModelTests.swift
@@ -73,10 +73,7 @@ final class ProductListingViewModelTests: XCTestCase {
                                           products: Array(Product.fixtures.prefix(5)))
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state,
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state, afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertTrue(sut.state.isSuccess)
         XCTAssertEqual(sut.title, "Women's Clothing")
@@ -108,10 +105,7 @@ final class ProductListingViewModelTests: XCTestCase {
                                           products: Array(Product.fixtures.prefix(5)))
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state,
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state, afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertTrue(sut.state.isSuccess)
         XCTAssertEqual(sut.title, "Women's Clothing")
@@ -123,10 +117,7 @@ final class ProductListingViewModelTests: XCTestCase {
             throw BFFRequestError(type: .product(.noProducts(category: categoryId, query: query, sort: sort)))
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state,
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state, afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertTrue(sut.state.didFail)
         XCTAssertEqual(sut.state.failure, .generic)
@@ -158,17 +149,11 @@ final class ProductListingViewModelTests: XCTestCase {
             return ProductListing.fixture(products: Product.fixtures)
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state,
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state, afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertTrue(sut.state.isSuccess)
 
-        XCTAssertEmitsValue(
-            from: sut.$state,
-            afterTrigger: { sut.didDisplay(Product.fixtures.last!) }
-        )
+        XCTAssertEmitsValue(from: sut.$state, afterTrigger: { self.sut.didDisplay(Product.fixtures.last!) })
 
         XCTAssertTrue(sut.state.isLoadingNextPage)
     }
@@ -179,11 +164,7 @@ final class ProductListingViewModelTests: XCTestCase {
             ProductListing.fixture(products: Product.fixtures)
         }
 
-        XCTAssertNoEmit(
-            from: sut.$state,
-            afterTrigger: { sut.didDisplay(Product.fixtures.last!) },
-            timeout: inverted
-        )
+        XCTAssertNoEmit(from: sut.$state, afterTrigger: { self.sut.didDisplay(Product.fixtures.last!) })
     }
 
     func test_does_not_fetch_next_page_while_displaying_products() {
@@ -195,11 +176,7 @@ final class ProductListingViewModelTests: XCTestCase {
             ProductListing.fixture(products: Product.fixtures)
         }
 
-        XCTAssertNoEmit(
-            from: sut.$state,
-            afterTrigger: { sut.didDisplay(penultimateProduct) },
-            timeout: inverted
-        )
+        XCTAssertNoEmit(from: sut.$state, afterTrigger: { self.sut.didDisplay(penultimateProduct) })
     }
 
     func test_allows_showing_search_if_not_loading_and_not_showing_search_results() {
@@ -225,10 +202,7 @@ final class ProductListingViewModelTests: XCTestCase {
                                           products: Array(Product.fixtures.prefix(5)))
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state,
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state, afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertTrue(sut.state.isSuccess)
         XCTAssertTrue(sut.showSearchButton)
@@ -275,10 +249,7 @@ final class ProductListingViewModelTests: XCTestCase {
                                           products: Array(Product.fixtures.prefix(5)))
         }
 
-        XCTAssertEmitsValue(
-            from: sut.$state,
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state, afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertTrue(sut.state.isSuccess)
         XCTAssertFalse(sut.showSearchButton)

--- a/Alfie/AlfieTests/Features/Search/RecentSearchesViewModelTests.swift
+++ b/Alfie/AlfieTests/Features/Search/RecentSearchesViewModelTests.swift
@@ -37,7 +37,7 @@ final class RecentSearchesViewModelTests: XCTestCase {
             expectation.fulfill()
         }
         sut.didTapRemove(on: .recentSearch2)
-        waitForExpectations(timeout: defaultTimeout)
+        waitForExpectations(timeout: `default`)
     }
 
     func test_DidTapClearAll_InRecentsService_CallsRemoveAll() {
@@ -46,7 +46,7 @@ final class RecentSearchesViewModelTests: XCTestCase {
             expectation.fulfill()
         }
         sut.didTapClearAll()
-        waitForExpectations(timeout: defaultTimeout)
+        waitForExpectations(timeout: `default`)
     }
 
     func test_OnViewDidDisappear_InRecentsService_CallsSave() {
@@ -55,6 +55,6 @@ final class RecentSearchesViewModelTests: XCTestCase {
             expectation.fulfill()
         }
         sut.viewDidDisappear()
-        waitForExpectations(timeout: defaultTimeout)
+        waitForExpectations(timeout: `default`)
     }
 }

--- a/Alfie/AlfieTests/Features/Search/RecentSearchesViewModelTests.swift
+++ b/Alfie/AlfieTests/Features/Search/RecentSearchesViewModelTests.swift
@@ -37,7 +37,7 @@ final class RecentSearchesViewModelTests: XCTestCase {
             expectation.fulfill()
         }
         sut.didTapRemove(on: .recentSearch2)
-        waitForExpectations(timeout: `default`)
+        waitForExpectations(timeout: .default)
     }
 
     func test_DidTapClearAll_InRecentsService_CallsRemoveAll() {
@@ -46,7 +46,7 @@ final class RecentSearchesViewModelTests: XCTestCase {
             expectation.fulfill()
         }
         sut.didTapClearAll()
-        waitForExpectations(timeout: `default`)
+        waitForExpectations(timeout: .default)
     }
 
     func test_OnViewDidDisappear_InRecentsService_CallsSave() {
@@ -55,6 +55,6 @@ final class RecentSearchesViewModelTests: XCTestCase {
             expectation.fulfill()
         }
         sut.viewDidDisappear()
-        waitForExpectations(timeout: `default`)
+        waitForExpectations(timeout: .default)
     }
 }

--- a/Alfie/AlfieTests/Features/Search/SearchViewModelTests.swift
+++ b/Alfie/AlfieTests/Features/Search/SearchViewModelTests.swift
@@ -302,7 +302,7 @@ final class SearchViewModelTests: XCTestCase {
 
         sut.searchText = searchText
         testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: .default)
     }
 
     func test_sets_no_results_state_when_service_fails_to_get_suggestions() {

--- a/Alfie/AlfieTests/Features/Search/SearchViewModelTests.swift
+++ b/Alfie/AlfieTests/Features/Search/SearchViewModelTests.swift
@@ -54,18 +54,18 @@ final class SearchViewModelTests: XCTestCase {
 
         XCTAssertEmitsValue(
             from: sut.$state,
-            filteringValues: { $0.isSuccess },
+            where: { $0.isSuccess },
             afterTrigger: {
-                sut.searchText = "something"
-                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+                self.sut.searchText = "something"
+                self.testScheduler.advance(by: self.mockSearchService.suggestionsDebounceInterval)
             }
         )
 
         XCTAssertEmitsValue(
             from: sut.$state,
             afterTrigger: {
-                sut.searchText = ""
-                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+                self.sut.searchText = ""
+                self.testScheduler.advance(by: self.mockSearchService.suggestionsDebounceInterval)
             }
         )
 
@@ -81,19 +81,19 @@ final class SearchViewModelTests: XCTestCase {
 
         XCTAssertEmitsValue(
             from: sut.$state,
-            filteringValues: { $0.isSuccess },
+            where: { $0.isSuccess },
             afterTrigger: {
-                sut.searchText = "something"
-                mockRecentsService.recentSearches = [.text(value: "something")]
-                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+                self.sut.searchText = "something"
+                self.mockRecentsService.recentSearches = [.text(value: "something")]
+                self.testScheduler.advance(by: self.mockSearchService.suggestionsDebounceInterval)
             }
         )
 
         XCTAssertEmitsValue(
             from: sut.$state,
             afterTrigger: {
-                sut.searchText = ""
-                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+                self.sut.searchText = ""
+                self.testScheduler.advance(by: self.mockSearchService.suggestionsDebounceInterval)
             }
         )
 
@@ -106,8 +106,8 @@ final class SearchViewModelTests: XCTestCase {
         XCTAssertEmitsValue(
             from: sut.$state,
             afterTrigger: {
-                sut.searchText = "aaaa"
-                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+                self.sut.searchText = "aaaa"
+                self.testScheduler.advance(by: self.mockSearchService.suggestionsDebounceInterval)
             }
         )
 
@@ -133,20 +133,20 @@ final class SearchViewModelTests: XCTestCase {
 
         XCTAssertEmitsValue(
             from: sut.$state,
-            filteringValues: { $0.isSuccess },
+            where: { $0.isSuccess },
             afterTrigger: {
-                sut.searchText = "something"
-                mockRecentsService.recentSearches = [.text(value: "something")]
-                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+                self.sut.searchText = "something"
+                self.mockRecentsService.recentSearches = [.text(value: "something")]
+                self.testScheduler.advance(by: self.mockSearchService.suggestionsDebounceInterval)
             }
         )
 
         XCTAssertEmitsValue(
             from: sut.$state,
-            filteringValues: { $0 == .recentSearches },
+            where: { $0 == .recentSearches },
             afterTrigger: {
-                sut.searchText = ""
-                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+                self.sut.searchText = ""
+                self.testScheduler.advance(by: self.mockSearchService.suggestionsDebounceInterval)
             }
         )
     }
@@ -160,20 +160,20 @@ final class SearchViewModelTests: XCTestCase {
 
         XCTAssertEmitsValue(
             from: sut.$state,
-            filteringValues: { $0.isSuccess },
+            where: { $0.isSuccess },
             afterTrigger: {
-                sut.searchText = "something"
-                mockRecentsService.recentSearches = [.text(value: "something")]
-                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+                self.sut.searchText = "something"
+                self.mockRecentsService.recentSearches = [.text(value: "something")]
+                self.testScheduler.advance(by: self.mockSearchService.suggestionsDebounceInterval)
             }
         )
 
         XCTAssertEmitsValue(
             from: sut.$state.drop(while: { $0 == .loading }),
             afterTrigger: {
-                sut.searchText = ""
-                mockRecentsService.recentSearches = []
-                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+                self.sut.searchText = ""
+                self.mockRecentsService.recentSearches = []
+                self.testScheduler.advance(by: self.mockSearchService.suggestionsDebounceInterval)
             }
         )
 
@@ -191,7 +191,7 @@ final class SearchViewModelTests: XCTestCase {
         }
         sut.searchText = expectedRecentTerm
         sut.onSubmitSearch()
-        waitForExpectations(timeout: `default`)
+        waitForExpectations(timeout: .default)
     }
 
     func test_onSubmitTerm_emptySearch_addsToRecentsService() {
@@ -202,7 +202,7 @@ final class SearchViewModelTests: XCTestCase {
         }
         sut.searchText = ""
         sut.onSubmitSearch()
-        waitForExpectations(timeout: inverted)
+        waitForExpectations(timeout: .inverted)
     }
 
     func test_onViewDidDisappear_savesInRecentsService() {
@@ -211,7 +211,7 @@ final class SearchViewModelTests: XCTestCase {
             expectation.fulfill()
         }
         sut.viewDidDisappear()
-        waitForExpectations(timeout: `default`)
+        waitForExpectations(timeout: .default)
     }
 
     func test_show_recent_searches_when_view_appears_and_recents_are_available() {
@@ -219,7 +219,7 @@ final class SearchViewModelTests: XCTestCase {
 
         XCTAssertEmitsValue(
             from: sut.$state,
-            afterTrigger: { sut.viewDidAppear() }
+            afterTrigger: { self.sut.viewDidAppear() }
         )
 
         XCTAssertEqual(sut.state, .recentSearches)
@@ -229,15 +229,13 @@ final class SearchViewModelTests: XCTestCase {
         sut = .init(dependencies: testSchedulerMockDependencies)
         mockRecentsService.recentSearches = []
 
-        let result = XCTAssertNoEmit(
+        XCTAssertNoEmit(
             from: sut.$state.drop(while: { $0 == .empty }),
             afterTrigger: {
-                sut.viewDidAppear()
-                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
-            },
-            timeout: inverted
+                self.sut.viewDidAppear()
+                self.testScheduler.advance(by: self.mockSearchService.suggestionsDebounceInterval)
+            }
         )
-        XCTAssertTrue(result)
     }
 
     func test_does_not_show_recent_searches_when_view_appears_and_recents_service_is_not_available() {
@@ -249,15 +247,13 @@ final class SearchViewModelTests: XCTestCase {
         )
         sut = .init(dependencies: mockDependencies)
 
-        let result = XCTAssertNoEmit(
+        XCTAssertNoEmit(
             from: sut.$state.drop(while: { $0 == .empty }),
             afterTrigger: {
-                sut.viewDidAppear()
-                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
-            },
-            timeout: inverted
+                self.sut.viewDidAppear()
+                self.testScheduler.advance(by: self.mockSearchService.suggestionsDebounceInterval)
+            }
         )
-        XCTAssertTrue(result)
     }
 
     // MARK: - Special cases
@@ -271,10 +267,10 @@ final class SearchViewModelTests: XCTestCase {
 
         XCTAssertEmitsValue(
             from: sut.$state,
-            filteringValues: { $0 == .noResults },
+            where: { $0 == .noResults },
             afterTrigger: {
-                sut.searchText = "Something"
-                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+                self.sut.searchText = "Something"
+                self.testScheduler.advance(by: self.mockSearchService.suggestionsDebounceInterval)
             }
         )
 
@@ -283,8 +279,8 @@ final class SearchViewModelTests: XCTestCase {
         XCTAssertEmitsValue(
             from: sut.$state,
             afterTrigger: {
-                sut.searchText = "Somethin"
-                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+                self.sut.searchText = "Somethin"
+                self.testScheduler.advance(by: self.mockSearchService.suggestionsDebounceInterval)
             }
         )
 
@@ -306,7 +302,7 @@ final class SearchViewModelTests: XCTestCase {
 
         sut.searchText = searchText
         testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
     }
 
     func test_sets_no_results_state_when_service_fails_to_get_suggestions() {
@@ -318,10 +314,10 @@ final class SearchViewModelTests: XCTestCase {
 
         XCTAssertEmitsValue(
             from: sut.$state,
-            filteringValues: { $0 == .noResults },
+            where: { $0 == .noResults },
             afterTrigger: {
-                sut.searchText = "something"
-                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+                self.sut.searchText = "something"
+                self.testScheduler.advance(by: self.mockSearchService.suggestionsDebounceInterval)
             }
         )
 
@@ -337,10 +333,10 @@ final class SearchViewModelTests: XCTestCase {
 
         XCTAssertEmitsValue(
             from: sut.$state,
-            filteringValues: { $0 == .noResults },
+            where: { $0 == .noResults },
             afterTrigger: {
-                sut.searchText = "something"
-                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+                self.sut.searchText = "something"
+                self.testScheduler.advance(by: self.mockSearchService.suggestionsDebounceInterval)
             }
         )
 
@@ -356,10 +352,10 @@ final class SearchViewModelTests: XCTestCase {
 
         XCTAssertEmitsValue(
             from: sut.$state,
-            filteringValues: { $0.isSuccess },
+            where: { $0.isSuccess },
             afterTrigger: {
-                sut.searchText = "something"
-                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+                self.sut.searchText = "something"
+                self.testScheduler.advance(by: self.mockSearchService.suggestionsDebounceInterval)
             }
         )
 
@@ -382,10 +378,10 @@ final class SearchViewModelTests: XCTestCase {
 
         XCTAssertEmitsValue(
             from: sut.$state,
-            filteringValues: { $0.isSuccess },
+            where: { $0.isSuccess },
             afterTrigger: {
-                sut.searchText = "something"
-                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+                self.sut.searchText = "something"
+                self.testScheduler.advance(by: self.mockSearchService.suggestionsDebounceInterval)
             }
         )
 
@@ -403,10 +399,10 @@ final class SearchViewModelTests: XCTestCase {
 
         XCTAssertEmitsValue(
             from: sut.$state,
-            filteringValues: { $0.isSuccess },
+            where: { $0.isSuccess },
             afterTrigger: {
-                sut.searchText = "something"
-                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+                self.sut.searchText = "something"
+                self.testScheduler.advance(by: self.mockSearchService.suggestionsDebounceInterval)
             }
         )
 
@@ -429,10 +425,10 @@ final class SearchViewModelTests: XCTestCase {
 
         XCTAssertEmitsValue(
             from: sut.$state,
-            filteringValues: { $0.isSuccess },
+            where: { $0.isSuccess },
             afterTrigger: {
-                sut.searchText = "something"
-                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+                self.sut.searchText = "something"
+                self.testScheduler.advance(by: self.mockSearchService.suggestionsDebounceInterval)
             }
         )
 
@@ -452,10 +448,10 @@ final class SearchViewModelTests: XCTestCase {
 
         XCTAssertEmitsValue(
             from: sut.$state,
-            filteringValues: { $0.isSuccess },
+            where: { $0.isSuccess },
             afterTrigger: {
-                sut.searchText = "something"
-                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+                self.sut.searchText = "something"
+                self.testScheduler.advance(by: self.mockSearchService.suggestionsDebounceInterval)
             }
         )
 
@@ -478,10 +474,10 @@ final class SearchViewModelTests: XCTestCase {
 
         XCTAssertEmitsValue(
             from: sut.$state,
-            filteringValues: { $0.isSuccess },
+            where: { $0.isSuccess },
             afterTrigger: {
-                sut.searchText = "something"
-                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+                self.sut.searchText = "something"
+                self.testScheduler.advance(by: self.mockSearchService.suggestionsDebounceInterval)
             }
         )
 
@@ -499,10 +495,10 @@ final class SearchViewModelTests: XCTestCase {
 
         XCTAssertEmitsValue(
             from: sut.$state,
-            filteringValues: { $0.isSuccess },
+            where: { $0.isSuccess },
             afterTrigger: {
-                sut.searchText = "something"
-                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+                self.sut.searchText = "something"
+                self.testScheduler.advance(by: self.mockSearchService.suggestionsDebounceInterval)
             }
         )
 
@@ -518,7 +514,7 @@ final class SearchViewModelTests: XCTestCase {
             expectation.fulfill()
         }
         sut.onTapSearchSuggestion(suggestionTerm)
-        waitForExpectations(timeout: `default`)
+        waitForExpectations(timeout: .default)
     }
 
     func test_selecting_an_empty_suggested_term_does_not_add_to_recents_service() {
@@ -529,7 +525,7 @@ final class SearchViewModelTests: XCTestCase {
             expectation.fulfill()
         }
         sut.onTapSearchSuggestion(suggestionTerm)
-        waitForExpectations(timeout: inverted)
+        waitForExpectations(timeout: .inverted)
     }
 
     func test_suggestions_are_not_fetched_if_search_term_is_the_same_as_before() {
@@ -543,24 +539,22 @@ final class SearchViewModelTests: XCTestCase {
 
         XCTAssertEmitsValue(
             from: sut.$state,
-            filteringValues: { $0.isSuccess },
+            where: { $0.isSuccess },
             afterTrigger: {
-                sut.searchText = "something"
-                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+                self.sut.searchText = "something"
+                self.testScheduler.advance(by: self.mockSearchService.suggestionsDebounceInterval)
             }
         )
 
         XCTAssertEqual(sut.state.isSuccess, true)
 
-        let result = XCTAssertNoEmit(
+        XCTAssertNoEmit(
             from: sut.$state,
             afterTrigger: {
-                sut.searchText = "something"
-                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
-            },
-            timeout: inverted
+                self.sut.searchText = "something"
+                self.testScheduler.advance(by: self.mockSearchService.suggestionsDebounceInterval)
+            }
         )
-        XCTAssertTrue(result)
     }
 
     func test_suggestions_are_fetched_if_search_term_is_the_same_as_before_but_view_reappeared_in_between() {
@@ -574,10 +568,10 @@ final class SearchViewModelTests: XCTestCase {
 
         XCTAssertEmitsValue(
             from: sut.$state,
-            filteringValues: { $0.isSuccess },
+            where: { $0.isSuccess },
             afterTrigger: {
-                sut.searchText = "something"
-                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+                self.sut.searchText = "something"
+                self.testScheduler.advance(by: self.mockSearchService.suggestionsDebounceInterval)
             }
         )
 
@@ -588,8 +582,8 @@ final class SearchViewModelTests: XCTestCase {
         XCTAssertEmitsValue(
             from: sut.$state,
             afterTrigger: {
-                sut.searchText = "something"
-                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+                self.sut.searchText = "something"
+                self.testScheduler.advance(by: self.mockSearchService.suggestionsDebounceInterval)
             }
         )
 

--- a/Alfie/AlfieTests/Features/Search/SearchViewModelTests.swift
+++ b/Alfie/AlfieTests/Features/Search/SearchViewModelTests.swift
@@ -1,31 +1,43 @@
+import CombineSchedulers
 import XCTest
 import Mocks
 import Models
 @testable import Alfie
 
 final class SearchViewModelTests: XCTestCase {
-    private var mockDependencies: SearchDependencyContainer!
+    private var immediateSchedulerMockDependencies: SearchDependencyContainer!
+    private var testSchedulerMockDependencies: SearchDependencyContainer!
     private var mockRecentsService: MockRecentsService!
     private var mockSearchService: MockSearchService!
     private var sut: SearchViewModel!
     private let mockAnalytics = MockAnalyticsTracker().eraseToAnyAnalyticsTracker()
+    private var testScheduler: TestSchedulerOf<DispatchQueue>!
 
     override func setUpWithError() throws {
         try super.setUpWithError()
         mockRecentsService = .init()
         mockSearchService = .init()
-        mockDependencies = SearchDependencyContainer(
-            executionQueue: DispatchQueue.global(),
+        immediateSchedulerMockDependencies = SearchDependencyContainer(
+            scheduler: .immediate,
             recentsService: mockRecentsService,
             searchService: mockSearchService,
             analytics: mockAnalytics
         )
-        sut = .init(dependencies: mockDependencies)
+        testScheduler = DispatchQueue.test
+        testSchedulerMockDependencies = SearchDependencyContainer(
+            scheduler: testScheduler.eraseToAnyScheduler(),
+            recentsService: mockRecentsService,
+            searchService: mockSearchService,
+            analytics: mockAnalytics
+        )
+        sut = .init(dependencies: immediateSchedulerMockDependencies)
     }
 
     override func tearDownWithError() throws {
         sut = nil
-        mockDependencies = nil
+        immediateSchedulerMockDependencies = nil
+        testScheduler = nil
+        testSchedulerMockDependencies = nil
         mockRecentsService = nil
         mockSearchService = nil
         try super.tearDownWithError()
@@ -34,33 +46,72 @@ final class SearchViewModelTests: XCTestCase {
     // MARK: - Search text
 
     func test_searchText_withEmptyText_setsToEmptyState() {
-        sut.searchText = ""
-        waitUntil(publisher: sut.$state.eraseToAnyPublisher(), 
-                  emitsValue: .empty,
-                  timeout: defaultTimeout)
+        sut = .init(dependencies: testSchedulerMockDependencies)
+
+        mockSearchService.onGetSuggestionCalled = { _ in
+            .fixture(brands: [.fixture()])
+        }
+
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            filteringValues: { $0.isSuccess },
+            afterTrigger: {
+                sut.searchText = "something"
+                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+            }
+        )
+
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            afterTrigger: {
+                sut.searchText = ""
+                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+            }
+        )
+
+        XCTAssertEqual(sut.state, .empty)
     }
 
     func test_searchText_withEmptyText_setsToRecentSearches() {
-        mockRecentsService.recentSearches = [.text(value: "something")]
-        sut = .init(dependencies: mockDependencies)
-        sut.searchText = ""
-        waitUntil(publisher: sut.$state.eraseToAnyPublisher(),
-                  emitsValue: .recentSearches,
-                  timeout: defaultTimeout)
-    }
+        sut = .init(dependencies: testSchedulerMockDependencies)
 
-    func test_searchText_withText_setsToEmptyState() {
-        sut.searchText = "aa"
-        waitUntil(publisher: sut.$state.eraseToAnyPublisher(),
-                  emitsValue: .empty,
-                  timeout: defaultTimeout)
+        mockSearchService.onGetSuggestionCalled = { _ in
+            .fixture(brands: [.fixture()])
+        }
+
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            filteringValues: { $0.isSuccess },
+            afterTrigger: {
+                sut.searchText = "something"
+                mockRecentsService.recentSearches = [.text(value: "something")]
+                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+            }
+        )
+
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            afterTrigger: {
+                sut.searchText = ""
+                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+            }
+        )
+
+        XCTAssertEqual(sut.state, .recentSearches)
     }
 
     func test_searchText_SetsToLoadingState() {
-        sut.searchText = "aaaa"
-        waitUntil(publisher: sut.$state.eraseToAnyPublisher(),
-                  emitsValue: .loading,
-                  timeout: defaultTimeout)
+        sut = .init(dependencies: testSchedulerMockDependencies)
+
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            afterTrigger: {
+                sut.searchText = "aaaa"
+                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+            }
+        )
+
+        XCTAssertEqual(sut.state, .loading)
     }
 
     func test_isSubmitionAllowed_withEmptySearchTerm_returnsFalse() {
@@ -74,33 +125,59 @@ final class SearchViewModelTests: XCTestCase {
     }
 
     func test_clearing_search_text_when_recents_are_available_sets_recents_state() {
-        waitUntil(publisher: sut.$state.eraseToAnyPublisher(),
-                  emitsValue: .empty,
-                  asyncOperation: { self.sut.searchText = "something" },
-                  timeout: defaultTimeout)
-        
-        mockRecentsService.recentSearches = [.text(value: "something")]
+        sut = .init(dependencies: testSchedulerMockDependencies)
 
-        waitUntil(publisher: sut.$state.eraseToAnyPublisher(),
-                  emitsValue: .recentSearches,
-                  asyncOperation: { self.sut.searchText = "" },
-                  timeout: defaultTimeout)
+        mockSearchService.onGetSuggestionCalled = { _ in
+            .fixture(brands: [.fixture()])
+        }
+
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            filteringValues: { $0.isSuccess },
+            afterTrigger: {
+                sut.searchText = "something"
+                mockRecentsService.recentSearches = [.text(value: "something")]
+                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+            }
+        )
+
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            filteringValues: { $0 == .recentSearches },
+            afterTrigger: {
+                sut.searchText = ""
+                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+            }
+        )
     }
 
     func test_clearing_search_text_when_recents_are_not_available_sets_empty_state() {
-        mockRecentsService.recentSearches = [.text(value: "something")]
+        sut = .init(dependencies: testSchedulerMockDependencies)
 
-        waitUntil(publisher: sut.$state.eraseToAnyPublisher(),
-                  emitsValue: .recentSearches,
-                  asyncOperation: { self.sut.searchText = "" },
-                  timeout: defaultTimeout)
+        mockSearchService.onGetSuggestionCalled = { _ in
+            .fixture(brands: [.fixture()])
+        }
 
-        mockRecentsService.recentSearches = []
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            filteringValues: { $0.isSuccess },
+            afterTrigger: {
+                sut.searchText = "something"
+                mockRecentsService.recentSearches = [.text(value: "something")]
+                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+            }
+        )
 
-        waitUntil(publisher: sut.$state.eraseToAnyPublisher(),
-                  emitsValue: .empty,
-                  asyncOperation: { self.sut.searchText = "" },
-                  timeout: defaultTimeout)
+        XCTAssertEmitsValue(
+            from: sut.$state.drop(while: { $0 == .loading }),
+            afterTrigger: {
+                sut.searchText = ""
+                mockRecentsService.recentSearches = []
+                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+            }
+        )
+
+        XCTAssertEqual(sut.state, .empty)
     }
 
     // MARK: - Recent Seaches
@@ -114,7 +191,7 @@ final class SearchViewModelTests: XCTestCase {
         }
         sut.searchText = expectedRecentTerm
         sut.onSubmitSearch()
-        waitForExpectations(timeout: defaultTimeout)
+        waitForExpectations(timeout: `default`)
     }
 
     func test_onSubmitTerm_emptySearch_addsToRecentsService() {
@@ -125,7 +202,7 @@ final class SearchViewModelTests: XCTestCase {
         }
         sut.searchText = ""
         sut.onSubmitSearch()
-        waitForExpectations(timeout: defaultTimeout)
+        waitForExpectations(timeout: inverted)
     }
 
     func test_onViewDidDisappear_savesInRecentsService() {
@@ -134,54 +211,82 @@ final class SearchViewModelTests: XCTestCase {
             expectation.fulfill()
         }
         sut.viewDidDisappear()
-        waitForExpectations(timeout: defaultTimeout)
+        waitForExpectations(timeout: `default`)
     }
 
     func test_show_recent_searches_when_view_appears_and_recents_are_available() {
         mockRecentsService.recentSearches = [.text(value: "something")]
 
-       captureEvent(fromPublisher: sut.$state.eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertEqual(sut.state, .recentSearches)
     }
 
     func test_does_not_show_recent_searches_when_view_appears_and_recents_are_not_available() {
+        sut = .init(dependencies: testSchedulerMockDependencies)
         mockRecentsService.recentSearches = []
 
-        let result = assertNoEvent(from: sut.$state.drop(while: { $0 == .empty }).eraseToAnyPublisher(), afterTrigger: { sut.viewDidAppear() }, timeout: defaultTimeout)
+        let result = XCTAssertNoEmit(
+            from: sut.$state.drop(while: { $0 == .empty }),
+            afterTrigger: {
+                sut.viewDidAppear()
+                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+            },
+            timeout: inverted
+        )
         XCTAssertTrue(result)
     }
 
     func test_does_not_show_recent_searches_when_view_appears_and_recents_service_is_not_available() {
-        mockDependencies = SearchDependencyContainer(
+        let mockDependencies = SearchDependencyContainer(
+            scheduler: testScheduler.eraseToAnyScheduler(),
             recentsService: nil,
             searchService: mockSearchService,
             analytics: mockAnalytics
         )
         sut = .init(dependencies: mockDependencies)
 
-        let result = assertNoEvent(from: sut.$state.drop(while: { $0 == .empty }).eraseToAnyPublisher(), afterTrigger: { sut.viewDidAppear() }, timeout: defaultTimeout)
+        let result = XCTAssertNoEmit(
+            from: sut.$state.drop(while: { $0 == .empty }),
+            afterTrigger: {
+                sut.viewDidAppear()
+                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+            },
+            timeout: inverted
+        )
         XCTAssertTrue(result)
     }
 
     // MARK: - Special cases
 
     func test_updating_search_text_sets_loading_state_if_current_state_is_no_results() {
+        sut = .init(dependencies: testSchedulerMockDependencies)
+
         mockSearchService.onGetSuggestionCalled = { _ in
-            return .fixture()
+            .fixture()
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0 != .noResults }).eraseToAnyPublisher(), afterTrigger: {
-            sut.searchText = "Something"
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            filteringValues: { $0 == .noResults },
+            afterTrigger: {
+                sut.searchText = "Something"
+                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+            }
+        )
 
         XCTAssertEqual(sut.state, .noResults)
 
-       captureEvent(fromPublisher: sut.$state.eraseToAnyPublisher(), afterTrigger: {
-            sut.searchText = "Somethin"
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            afterTrigger: {
+                sut.searchText = "Somethin"
+                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+            }
+        )
 
         XCTAssertEqual(sut.state, .loading)
     }
@@ -189,6 +294,8 @@ final class SearchViewModelTests: XCTestCase {
     // MARK: - Search Suggestions
 
     func test_gets_search_suggestions_from_service_when_search_text_is_updated() {
+        sut = .init(dependencies: testSchedulerMockDependencies)
+
         let searchText = "something"
         let expectation = expectation(description: "Wait for service call")
         mockSearchService.onGetSuggestionCalled = { term in
@@ -198,41 +305,63 @@ final class SearchViewModelTests: XCTestCase {
         }
 
         sut.searchText = searchText
-        wait(for: [expectation], timeout: defaultTimeout)
+        testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+        wait(for: [expectation], timeout: `default`)
     }
 
     func test_sets_no_results_state_when_service_fails_to_get_suggestions() {
+        sut = .init(dependencies: testSchedulerMockDependencies)
+
         mockSearchService.onGetSuggestionCalled = { _ in
             throw BFFRequestError(type: .generic)
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0 != .noResults }).eraseToAnyPublisher(), afterTrigger: {
-            sut.searchText = "something"
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            filteringValues: { $0 == .noResults },
+            afterTrigger: {
+                sut.searchText = "something"
+                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+            }
+        )
 
         XCTAssertEqual(sut.state, .noResults)
     }
 
     func test_sets_no_results_state_when_service_returns_no_suggestions() {
+        sut = .init(dependencies: testSchedulerMockDependencies)
+
         mockSearchService.onGetSuggestionCalled = { _ in
             .fixture()
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { $0 != .noResults }).eraseToAnyPublisher(), afterTrigger: {
-            sut.searchText = "something"
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            filteringValues: { $0 == .noResults },
+            afterTrigger: {
+                sut.searchText = "something"
+                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+            }
+        )
 
         XCTAssertEqual(sut.state, .noResults)
     }
 
     func test_sets_success_state_when_service_returns_suggestions() {
+        sut = .init(dependencies: testSchedulerMockDependencies)
+
         mockSearchService.onGetSuggestionCalled = { _ in
             .fixture(brands: [.fixture()])
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { !$0.isSuccess }).eraseToAnyPublisher(), afterTrigger: {
-            sut.searchText = "something"
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            filteringValues: { $0.isSuccess },
+            afterTrigger: {
+                sut.searchText = "something"
+                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+            }
+        )
 
         XCTAssertEqual(sut.state.isSuccess, true)
     }
@@ -242,6 +371,8 @@ final class SearchViewModelTests: XCTestCase {
     }
 
     func test_suggestion_terms_are_available_after_fetching() {
+        sut = .init(dependencies: testSchedulerMockDependencies)
+
         mockSearchService.onGetSuggestionCalled = { _ in
             .fixture(keywords: [
                 .fixture(term: "Term 1"),
@@ -249,9 +380,14 @@ final class SearchViewModelTests: XCTestCase {
             ])
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { !$0.isSuccess }).eraseToAnyPublisher(), afterTrigger: {
-            sut.searchText = "something"
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            filteringValues: { $0.isSuccess },
+            afterTrigger: {
+                sut.searchText = "something"
+                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+            }
+        )
 
         XCTAssertEqual(sut.suggestionTerms.count, 2)
         XCTAssertEqual(sut.suggestionTerms[0].term, "Term 1")
@@ -259,13 +395,20 @@ final class SearchViewModelTests: XCTestCase {
     }
 
     func test_suggestion_terms_returned_are_truncated_when_many_are_fetched() {
+        sut = .init(dependencies: testSchedulerMockDependencies)
+
         mockSearchService.onGetSuggestionCalled = { _ in
             .fixture(keywords: Array(repeating: SearchSuggestionKeyword.fixture(), count: 100))
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { !$0.isSuccess }).eraseToAnyPublisher(), afterTrigger: {
-            sut.searchText = "something"
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            filteringValues: { $0.isSuccess },
+            afterTrigger: {
+                sut.searchText = "something"
+                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+            }
+        )
 
         XCTAssertEqual(sut.suggestionTerms.count, 6)
     }
@@ -275,6 +418,8 @@ final class SearchViewModelTests: XCTestCase {
     }
 
     func test_suggestion_brands_are_available_after_fetching() {
+        sut = .init(dependencies: testSchedulerMockDependencies)
+
         mockSearchService.onGetSuggestionCalled = { _ in
             .fixture(brands: [
                 .fixture(name: "Brand 1", slug: "slug-1"),
@@ -282,9 +427,14 @@ final class SearchViewModelTests: XCTestCase {
             ])
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { !$0.isSuccess }).eraseToAnyPublisher(), afterTrigger: {
-            sut.searchText = "something"
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            filteringValues: { $0.isSuccess },
+            afterTrigger: {
+                sut.searchText = "something"
+                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+            }
+        )
 
         XCTAssertEqual(sut.suggestionBrands.count, 2)
         XCTAssertEqual(sut.suggestionBrands[0].name, "Brand 1")
@@ -294,13 +444,20 @@ final class SearchViewModelTests: XCTestCase {
     }
 
     func test_suggestion_brands_returned_are_truncated_when_many_are_fetched() {
+        sut = .init(dependencies: testSchedulerMockDependencies)
+
         mockSearchService.onGetSuggestionCalled = { _ in
             .fixture(brands: Array(repeating: SearchSuggestionBrand.fixture(), count: 100))
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { !$0.isSuccess }).eraseToAnyPublisher(), afterTrigger: {
-            sut.searchText = "something"
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            filteringValues: { $0.isSuccess },
+            afterTrigger: {
+                sut.searchText = "something"
+                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+            }
+        )
 
         XCTAssertEqual(sut.suggestionBrands.count, 6)
     }
@@ -310,6 +467,8 @@ final class SearchViewModelTests: XCTestCase {
     }
 
     func test_suggestion_products_are_available_after_fetching() {
+        sut = .init(dependencies: testSchedulerMockDependencies)
+
         mockSearchService.onGetSuggestionCalled = { _ in
             .fixture(products: [
                 .fixture(name: "Product 1"),
@@ -317,9 +476,14 @@ final class SearchViewModelTests: XCTestCase {
             ])
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { !$0.isSuccess }).eraseToAnyPublisher(), afterTrigger: {
-            sut.searchText = "something"
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            filteringValues: { $0.isSuccess },
+            afterTrigger: {
+                sut.searchText = "something"
+                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+            }
+        )
 
         XCTAssertEqual(sut.suggestionProducts.count, 2)
         XCTAssertEqual(sut.suggestionProducts[0].name, "Product 1")
@@ -327,13 +491,20 @@ final class SearchViewModelTests: XCTestCase {
     }
 
     func test_suggestion_products_returned_are_truncated_when_many_are_fetched() {
+        sut = .init(dependencies: testSchedulerMockDependencies)
+
         mockSearchService.onGetSuggestionCalled = { _ in
             .fixture(products: Array(repeating: SearchSuggestionProduct.fixture(), count: 100))
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { !$0.isSuccess }).eraseToAnyPublisher(), afterTrigger: {
-            sut.searchText = "something"
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            filteringValues: { $0.isSuccess },
+            afterTrigger: {
+                sut.searchText = "something"
+                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+            }
+        )
 
         XCTAssertEqual(sut.suggestionProducts.count, 8)
     }
@@ -347,7 +518,7 @@ final class SearchViewModelTests: XCTestCase {
             expectation.fulfill()
         }
         sut.onTapSearchSuggestion(suggestionTerm)
-        waitForExpectations(timeout: defaultTimeout)
+        waitForExpectations(timeout: `default`)
     }
 
     func test_selecting_an_empty_suggested_term_does_not_add_to_recents_service() {
@@ -358,44 +529,69 @@ final class SearchViewModelTests: XCTestCase {
             expectation.fulfill()
         }
         sut.onTapSearchSuggestion(suggestionTerm)
-        waitForExpectations(timeout: defaultTimeout)
+        waitForExpectations(timeout: inverted)
     }
 
     func test_suggestions_are_not_fetched_if_search_term_is_the_same_as_before() {
+        sut = .init(dependencies: testSchedulerMockDependencies)
+
         mockSearchService.onGetSuggestionCalled = { _ in
             .fixture(brands: [
                 .fixture(name: "Brand 1", slug: "slug-1"),
             ])
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { !$0.isSuccess }).eraseToAnyPublisher(), afterTrigger: {
-            sut.searchText = "something"
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            filteringValues: { $0.isSuccess },
+            afterTrigger: {
+                sut.searchText = "something"
+                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+            }
+        )
 
         XCTAssertEqual(sut.state.isSuccess, true)
 
-        let result = assertNoEvent(from: sut.$state.eraseToAnyPublisher(), afterTrigger: { sut.searchText = "something" }, timeout: defaultTimeout)
+        let result = XCTAssertNoEmit(
+            from: sut.$state,
+            afterTrigger: {
+                sut.searchText = "something"
+                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+            },
+            timeout: inverted
+        )
         XCTAssertTrue(result)
     }
 
     func test_suggestions_are_fetched_if_search_term_is_the_same_as_before_but_view_reappeared_in_between() {
+        sut = .init(dependencies: testSchedulerMockDependencies)
+
         mockSearchService.onGetSuggestionCalled = { _ in
             .fixture(brands: [
                 .fixture(name: "Brand 1", slug: "slug-1"),
             ])
         }
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { !$0.isSuccess }).eraseToAnyPublisher(), afterTrigger: {
-            sut.searchText = "something"
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            filteringValues: { $0.isSuccess },
+            afterTrigger: {
+                sut.searchText = "something"
+                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+            }
+        )
 
         XCTAssertEqual(sut.state.isSuccess, true)
 
         sut.viewDidAppear()
 
-       captureEvent(fromPublisher: sut.$state.eraseToAnyPublisher(), afterTrigger: {
-            sut.searchText = "something"
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            afterTrigger: {
+                sut.searchText = "something"
+                testScheduler.advance(by: mockSearchService.suggestionsDebounceInterval)
+            }
+        )
 
         XCTAssertEqual(sut.state, .loading)
     }

--- a/Alfie/AlfieTests/Features/WebViewModelTests.swift
+++ b/Alfie/AlfieTests/Features/WebViewModelTests.swift
@@ -44,11 +44,7 @@ final class WebViewModelTests: XCTestCase {
 
         XCTAssertNil(sut.state.url)
 
-        XCTAssertEmitsValue(
-            from: sut.$state,
-            filteringValues: { $0.isReady },
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state, where: \.isReady, afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertEqual(sut.state.url?.absoluteString, url?.absoluteString)
     }
@@ -62,11 +58,7 @@ final class WebViewModelTests: XCTestCase {
 
         XCTAssertNil(sut.state.url)
 
-        XCTAssertEmitsValue(
-            from: sut.$state,
-            filteringValues: { $0.isReady },
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state, where: \.isReady, afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertEqual(sut.state.url?.absoluteString, url?.absoluteString)
     }
@@ -75,10 +67,7 @@ final class WebViewModelTests: XCTestCase {
         let url = URL(string: "http://some.url")
         sut = .init(url: url, dependencies: mockDependencies)
 
-        XCTAssertEmitsValue(
-            from: sut.$state,
-            afterTrigger: { sut.webViewStarted() }
-        )
+        XCTAssertEmitsValue(from: sut.$state, afterTrigger: { self.sut.webViewStarted() })
 
         XCTAssertEqual(sut.state.isLoading, true)
     }
@@ -87,10 +76,7 @@ final class WebViewModelTests: XCTestCase {
         let url = URL(string: "http://some.url")
         sut = .init(url: url, dependencies: mockDependencies)
 
-        XCTAssertEmitsValue(
-            from: sut.$state,
-            afterTrigger: { sut.webViewFailed() }
-        )
+        XCTAssertEmitsValue(from: sut.$state, afterTrigger: { self.sut.webViewFailed() })
 
         XCTAssertEqual(sut.state.failure, .generic)
     }
@@ -99,10 +85,7 @@ final class WebViewModelTests: XCTestCase {
         let url = URL(string: "http://some.url")
         sut = .init(url: url, dependencies: mockDependencies)
 
-        XCTAssertEmitsValue(
-            from: sut.$state,
-            afterTrigger: { sut.webViewFinished() }
-        )
+        XCTAssertEmitsValue(from: sut.$state, afterTrigger: { self.sut.webViewFinished() })
 
         XCTAssertEqual(sut.state.isLoaded, true)
     }
@@ -113,11 +96,7 @@ final class WebViewModelTests: XCTestCase {
 
         XCTAssertNil(sut.state.url)
 
-        XCTAssertEmitsValue(
-            from: sut.$state,
-            filteringValues: { $0.isReady },
-            afterTrigger: { sut.tryAgain() }
-        )
+        XCTAssertEmitsValue(from: sut.$state, where: \.isReady, afterTrigger: { self.sut.tryAgain() })
 
         XCTAssertEqual(sut.state.url?.absoluteString, url?.absoluteString)
     }
@@ -126,11 +105,7 @@ final class WebViewModelTests: XCTestCase {
         let url = URL(string: "http://some.url")!
         sut = .init(url: url, dependencies: mockDependencies)
 
-        XCTAssertEmitsValue(
-            from: sut.$state,
-            filteringValues: { $0.isReady },
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state, where: \.isReady, afterTrigger: { self.sut.viewDidAppear() })
 
         let result = sut.canOpenUrl(url)
         XCTAssertFalse(result)
@@ -140,11 +115,7 @@ final class WebViewModelTests: XCTestCase {
         let baseUrl = URL(string: "http://some.url")
         sut = .init(url: baseUrl, dependencies: mockDependencies)
 
-        XCTAssertEmitsValue(
-            from: sut.$state,
-            filteringValues: { $0.isReady },
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state, where: \.isReady, afterTrigger: { self.sut.viewDidAppear() })
 
         let testUrl = URL(string: "http://other.url")!
         mockDeepLinkService.onDeepLinkTypeCalled = { url in
@@ -160,11 +131,7 @@ final class WebViewModelTests: XCTestCase {
         let baseUrl = URL(string: "http://some.url")
         sut = .init(url: baseUrl, dependencies: mockDependencies)
 
-        XCTAssertEmitsValue(
-            from: sut.$state,
-            filteringValues: { $0.isReady },
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state, where: \.isReady, afterTrigger: { self.sut.viewDidAppear() })
 
         let testUrl = URL(string: "http://other.url")!
         mockDeepLinkService.onDeepLinkTypeCalled = { url in
@@ -180,11 +147,7 @@ final class WebViewModelTests: XCTestCase {
         let baseUrl = URL(string: "http://some.url")
         sut = .init(url: baseUrl, dependencies: mockDependencies)
 
-        XCTAssertEmitsValue(
-            from: sut.$state,
-            filteringValues: { $0.isReady },
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state, where: \.isReady, afterTrigger: { self.sut.viewDidAppear() })
 
         let testUrl = URL(string: "http://other.url")!
         mockDeepLinkService.onDeepLinkTypeCalled = { url in
@@ -200,11 +163,7 @@ final class WebViewModelTests: XCTestCase {
         let baseUrl = URL(string: "http://some.url")
         sut = .init(url: baseUrl, dependencies: mockDependencies)
 
-        XCTAssertEmitsValue(
-            from: sut.$state,
-            filteringValues: { $0.isReady },
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state, where: \.isReady, afterTrigger: { self.sut.viewDidAppear() })
 
         let testUrl = URL(string: "http://other.url")!
         mockDeepLinkService.onDeepLinkTypeCalled = { url in
@@ -228,7 +187,7 @@ final class WebViewModelTests: XCTestCase {
 
         sut = .init(url: url, dependencies: mockDependencies)
         sut.handleLink(withUrl: url)
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
     }
 
     func test_forwards_links_to_deeplink_handler_on_url_change() {
@@ -248,7 +207,7 @@ final class WebViewModelTests: XCTestCase {
 
         sut = .init(url: baseUrl, dependencies: mockDependencies)
         sut.webViewUrlChanged(testUrl)
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
     }
 
     func test_navigates_back_if_url_change_is_handled_by_external_handler() {
@@ -258,10 +217,7 @@ final class WebViewModelTests: XCTestCase {
             return true
         })
 
-        XCTAssertEmitsValue(
-            from: sut.$state,
-            afterTrigger: { sut.webViewUrlChanged(baseUrl) }
-        )
+        XCTAssertEmitsValue(from: sut.$state, afterTrigger: { self.sut.webViewUrlChanged(baseUrl) })
 
         XCTAssertEqual(sut.shouldNavigateBack, true)
     }
@@ -275,10 +231,7 @@ final class WebViewModelTests: XCTestCase {
 
         sut = .init(url: baseUrl, dependencies: mockDependencies, urlChangeHandler: nil)
 
-        XCTAssertEmitsValue(
-            from: sut.$state,
-            afterTrigger: { sut.webViewUrlChanged(testUrl) }
-        )
+        XCTAssertEmitsValue(from: sut.$state, afterTrigger: { self.sut.webViewUrlChanged(testUrl) })
 
         XCTAssertEqual(sut.shouldNavigateBack, true)
     }
@@ -287,12 +240,7 @@ final class WebViewModelTests: XCTestCase {
         let baseUrl = URL(string: "http://some.url")!
         sut = .init(url: baseUrl, dependencies: mockDependencies, urlChangeHandler: nil)
 
-        let result = XCTAssertNoEmit(
-            from: sut.$state,
-            afterTrigger: { sut.webViewUrlChanged(baseUrl) },
-            timeout: inverted
-        )
-        XCTAssertTrue(result)
+        XCTAssertNoEmit(from: sut.$state, afterTrigger: { self.sut.webViewUrlChanged(baseUrl) })
         XCTAssertTrue(sut.state.isEmpty)
     }
 
@@ -305,10 +253,7 @@ final class WebViewModelTests: XCTestCase {
     func test_state_is_no_url_error_after_update_if_no_url_or_feature_is_supplied_on_init() {
         sut = .init(url: nil, dependencies: mockDependencies)
 
-        XCTAssertEmitsValue(
-            from: sut.$state,
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state, afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertEqual(sut.state.failure, .noUrl)
     }
@@ -316,10 +261,7 @@ final class WebViewModelTests: XCTestCase {
     func test_state_is_loading_when_updating_url_for_feature() {
         sut = .init(webFeature: .addresses, dependencies: mockDependencies)
 
-        XCTAssertEmitsValue(
-            from: sut.$state,
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state, afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertEqual(sut.state.isLoading, true)
     }
@@ -330,11 +272,7 @@ final class WebViewModelTests: XCTestCase {
         }
         sut = .init(webFeature: .addresses, dependencies: mockDependencies)
 
-        XCTAssertEmitsValue(
-            from: sut.$state,
-            filteringValues: { $0.didFail },
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state, where: { $0.didFail }, afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertEqual(sut.state.failure, .noUrl)
     }
@@ -346,11 +284,7 @@ final class WebViewModelTests: XCTestCase {
         }
         sut = .init(webFeature: .addresses, dependencies: mockDependencies)
 
-        XCTAssertEmitsValue(
-            from: sut.$state,
-            filteringValues: { $0.isReady },
-            afterTrigger: { sut.viewDidAppear() }
-        )
+        XCTAssertEmitsValue(from: sut.$state, where: \.isReady, afterTrigger: { self.sut.viewDidAppear() })
 
         XCTAssertEqual(sut.state.isReady, true)
     }

--- a/Alfie/AlfieTests/Features/WebViewModelTests.swift
+++ b/Alfie/AlfieTests/Features/WebViewModelTests.swift
@@ -44,9 +44,11 @@ final class WebViewModelTests: XCTestCase {
 
         XCTAssertNil(sut.state.url)
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { !$0.isReady }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            filteringValues: { $0.isReady },
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertEqual(sut.state.url?.absoluteString, url?.absoluteString)
     }
@@ -60,9 +62,11 @@ final class WebViewModelTests: XCTestCase {
 
         XCTAssertNil(sut.state.url)
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { !$0.isReady }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            filteringValues: { $0.isReady },
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertEqual(sut.state.url?.absoluteString, url?.absoluteString)
     }
@@ -71,9 +75,10 @@ final class WebViewModelTests: XCTestCase {
         let url = URL(string: "http://some.url")
         sut = .init(url: url, dependencies: mockDependencies)
 
-       captureEvent(fromPublisher: sut.$state.eraseToAnyPublisher(), afterTrigger: {
-            sut.webViewStarted()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            afterTrigger: { sut.webViewStarted() }
+        )
 
         XCTAssertEqual(sut.state.isLoading, true)
     }
@@ -82,9 +87,10 @@ final class WebViewModelTests: XCTestCase {
         let url = URL(string: "http://some.url")
         sut = .init(url: url, dependencies: mockDependencies)
 
-       captureEvent(fromPublisher: sut.$state.eraseToAnyPublisher(), afterTrigger: {
-            sut.webViewFailed()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            afterTrigger: { sut.webViewFailed() }
+        )
 
         XCTAssertEqual(sut.state.failure, .generic)
     }
@@ -93,9 +99,10 @@ final class WebViewModelTests: XCTestCase {
         let url = URL(string: "http://some.url")
         sut = .init(url: url, dependencies: mockDependencies)
 
-       captureEvent(fromPublisher: sut.$state.eraseToAnyPublisher(), afterTrigger: {
-            sut.webViewFinished()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            afterTrigger: { sut.webViewFinished() }
+        )
 
         XCTAssertEqual(sut.state.isLoaded, true)
     }
@@ -106,9 +113,11 @@ final class WebViewModelTests: XCTestCase {
 
         XCTAssertNil(sut.state.url)
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { !$0.isReady }).eraseToAnyPublisher(), afterTrigger: {
-            sut.tryAgain()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            filteringValues: { $0.isReady },
+            afterTrigger: { sut.tryAgain() }
+        )
 
         XCTAssertEqual(sut.state.url?.absoluteString, url?.absoluteString)
     }
@@ -117,9 +126,11 @@ final class WebViewModelTests: XCTestCase {
         let url = URL(string: "http://some.url")!
         sut = .init(url: url, dependencies: mockDependencies)
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { !$0.isReady }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            filteringValues: { $0.isReady },
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         let result = sut.canOpenUrl(url)
         XCTAssertFalse(result)
@@ -129,9 +140,11 @@ final class WebViewModelTests: XCTestCase {
         let baseUrl = URL(string: "http://some.url")
         sut = .init(url: baseUrl, dependencies: mockDependencies)
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { !$0.isReady }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            filteringValues: { $0.isReady },
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         let testUrl = URL(string: "http://other.url")!
         mockDeepLinkService.onDeepLinkTypeCalled = { url in
@@ -147,9 +160,11 @@ final class WebViewModelTests: XCTestCase {
         let baseUrl = URL(string: "http://some.url")
         sut = .init(url: baseUrl, dependencies: mockDependencies)
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { !$0.isReady }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            filteringValues: { $0.isReady },
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         let testUrl = URL(string: "http://other.url")!
         mockDeepLinkService.onDeepLinkTypeCalled = { url in
@@ -165,9 +180,11 @@ final class WebViewModelTests: XCTestCase {
         let baseUrl = URL(string: "http://some.url")
         sut = .init(url: baseUrl, dependencies: mockDependencies)
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { !$0.isReady }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            filteringValues: { $0.isReady },
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         let testUrl = URL(string: "http://other.url")!
         mockDeepLinkService.onDeepLinkTypeCalled = { url in
@@ -183,9 +200,11 @@ final class WebViewModelTests: XCTestCase {
         let baseUrl = URL(string: "http://some.url")
         sut = .init(url: baseUrl, dependencies: mockDependencies)
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { !$0.isReady }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            filteringValues: { $0.isReady },
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         let testUrl = URL(string: "http://other.url")!
         mockDeepLinkService.onDeepLinkTypeCalled = { url in
@@ -209,7 +228,7 @@ final class WebViewModelTests: XCTestCase {
 
         sut = .init(url: url, dependencies: mockDependencies)
         sut.handleLink(withUrl: url)
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: `default`)
     }
 
     func test_forwards_links_to_deeplink_handler_on_url_change() {
@@ -229,7 +248,7 @@ final class WebViewModelTests: XCTestCase {
 
         sut = .init(url: baseUrl, dependencies: mockDependencies)
         sut.webViewUrlChanged(testUrl)
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: `default`)
     }
 
     func test_navigates_back_if_url_change_is_handled_by_external_handler() {
@@ -238,10 +257,11 @@ final class WebViewModelTests: XCTestCase {
             XCTAssertEqual(url.absoluteString, baseUrl.absoluteString)
             return true
         })
-     
-       captureEvent(fromPublisher: sut.$state.eraseToAnyPublisher(), afterTrigger: {
-            sut.webViewUrlChanged(baseUrl)
-        })
+
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            afterTrigger: { sut.webViewUrlChanged(baseUrl) }
+        )
 
         XCTAssertEqual(sut.shouldNavigateBack, true)
     }
@@ -255,9 +275,10 @@ final class WebViewModelTests: XCTestCase {
 
         sut = .init(url: baseUrl, dependencies: mockDependencies, urlChangeHandler: nil)
 
-       captureEvent(fromPublisher: sut.$state.eraseToAnyPublisher(), afterTrigger: {
-            sut.webViewUrlChanged(testUrl)
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            afterTrigger: { sut.webViewUrlChanged(testUrl) }
+        )
 
         XCTAssertEqual(sut.shouldNavigateBack, true)
     }
@@ -266,10 +287,13 @@ final class WebViewModelTests: XCTestCase {
         let baseUrl = URL(string: "http://some.url")!
         sut = .init(url: baseUrl, dependencies: mockDependencies, urlChangeHandler: nil)
 
-        let result = assertNoEvent(from: sut.$state.eraseToAnyPublisher(), afterTrigger: {
-            sut.webViewUrlChanged(baseUrl)
-        })
+        let result = XCTAssertNoEmit(
+            from: sut.$state,
+            afterTrigger: { sut.webViewUrlChanged(baseUrl) },
+            timeout: inverted
+        )
         XCTAssertTrue(result)
+        XCTAssertTrue(sut.state.isEmpty)
     }
 
     func test_does_not_report_should_navigate_back_withou_valid_navigation_operation() {
@@ -281,9 +305,10 @@ final class WebViewModelTests: XCTestCase {
     func test_state_is_no_url_error_after_update_if_no_url_or_feature_is_supplied_on_init() {
         sut = .init(url: nil, dependencies: mockDependencies)
 
-       captureEvent(fromPublisher: sut.$state.eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertEqual(sut.state.failure, .noUrl)
     }
@@ -291,9 +316,10 @@ final class WebViewModelTests: XCTestCase {
     func test_state_is_loading_when_updating_url_for_feature() {
         sut = .init(webFeature: .addresses, dependencies: mockDependencies)
 
-       captureEvent(fromPublisher: sut.$state.eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertEqual(sut.state.isLoading, true)
     }
@@ -304,9 +330,11 @@ final class WebViewModelTests: XCTestCase {
         }
         sut = .init(webFeature: .addresses, dependencies: mockDependencies)
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { !$0.didFail }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            filteringValues: { $0.didFail },
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertEqual(sut.state.failure, .noUrl)
     }
@@ -318,9 +346,11 @@ final class WebViewModelTests: XCTestCase {
         }
         sut = .init(webFeature: .addresses, dependencies: mockDependencies)
 
-       captureEvent(fromPublisher: sut.$state.drop(while: { !$0.isReady }).eraseToAnyPublisher(), afterTrigger: {
-            sut.viewDidAppear()
-        })
+        XCTAssertEmitsValue(
+            from: sut.$state,
+            filteringValues: { $0.isReady },
+            afterTrigger: { sut.viewDidAppear() }
+        )
 
         XCTAssertEqual(sut.state.isReady, true)
     }

--- a/Alfie/AlfieTests/Features/WebViewModelTests.swift
+++ b/Alfie/AlfieTests/Features/WebViewModelTests.swift
@@ -187,7 +187,7 @@ final class WebViewModelTests: XCTestCase {
 
         sut = .init(url: url, dependencies: mockDependencies)
         sut.handleLink(withUrl: url)
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: .default)
     }
 
     func test_forwards_links_to_deeplink_handler_on_url_change() {
@@ -207,7 +207,7 @@ final class WebViewModelTests: XCTestCase {
 
         sut = .init(url: baseUrl, dependencies: mockDependencies)
         sut.webViewUrlChanged(testUrl)
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: .default)
     }
 
     func test_navigates_back_if_url_change_is_handled_by_external_handler() {

--- a/Alfie/AlfieTests/Navigation/Deeplink/Handlers/DeepLinkHandlerTests.swift
+++ b/Alfie/AlfieTests/Navigation/Deeplink/Handlers/DeepLinkHandlerTests.swift
@@ -113,7 +113,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         sut.handleDeepLink(deepLink)
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: .default)
     }
 
     func test_handles_web_links_when_ready() {
@@ -127,7 +127,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         sut.handleDeepLink(deepLink)
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: .default)
     }
 
     func test_handles_shop_links_without_route() {
@@ -141,7 +141,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         sut.handleDeepLink(deepLink)
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: .default)
     }
 
     func test_handles_shop_links_with_shop_route() {
@@ -155,7 +155,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         sut.handleDeepLink(deepLink)
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: .default)
     }
 
     func test_handles_shop_links_with_brands_route() {
@@ -169,7 +169,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         sut.handleDeepLink(deepLink)
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: .default)
     }
 
     func test_handles_shop_links_with_services_route() {
@@ -183,7 +183,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         sut.handleDeepLink(deepLink)
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: .default)
     }
 
     func test_handles_product_listing_links() {
@@ -208,7 +208,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         sut.handleDeepLink(deepLink)
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: .default)
     }
 
     func test_handles_product_details_links() {
@@ -223,7 +223,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         sut.handleDeepLink(deepLink)
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: .default)
     }
 
     func test_handles_bag_links() {
@@ -237,7 +237,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         sut.handleDeepLink(deepLink)
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: .default)
     }
 
     func test_handles_wishlist_links() {
@@ -251,7 +251,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         sut.handleDeepLink(deepLink)
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: .default)
     }
 
     func test_handles_account_links() {
@@ -265,7 +265,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         sut.handleDeepLink(deepLink)
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: .default)
     }
 
     func test_handles_but_ignores_unknown_links() {
@@ -306,7 +306,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         mockCoordinator.isReadyForNavigation = true
-        wait(for: [calledExpectation])
+        wait(for: [calledExpectation], timeout: .default)
     }
 
     func test_postpones_handling_web_links_until_it_becomes_ready() {
@@ -332,7 +332,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         mockCoordinator.isReadyForNavigation = true
-        wait(for: [calledExpectation])
+        wait(for: [calledExpectation], timeout: .default)
     }
 
     func test_can_handle_multiple_pending_links() {
@@ -358,7 +358,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         mockCoordinator.isReadyForNavigation = true
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: .default)
     }
 
     // MARK: - Private

--- a/Alfie/AlfieTests/Navigation/Deeplink/Handlers/DeepLinkHandlerTests.swift
+++ b/Alfie/AlfieTests/Navigation/Deeplink/Handlers/DeepLinkHandlerTests.swift
@@ -99,7 +99,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         sut.handleDeepLink(deepLink)
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: inverted)
     }
 
     func test_handles_home_links_when_ready() {
@@ -113,7 +113,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         sut.handleDeepLink(deepLink)
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: `default`)
     }
 
     func test_handles_web_links_when_ready() {
@@ -127,7 +127,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         sut.handleDeepLink(deepLink)
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: `default`)
     }
 
     func test_handles_shop_links_without_route() {
@@ -141,7 +141,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         sut.handleDeepLink(deepLink)
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: `default`)
     }
 
     func test_handles_shop_links_with_shop_route() {
@@ -155,7 +155,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         sut.handleDeepLink(deepLink)
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: `default`)
     }
 
     func test_handles_shop_links_with_brands_route() {
@@ -169,7 +169,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         sut.handleDeepLink(deepLink)
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: `default`)
     }
 
     func test_handles_shop_links_with_services_route() {
@@ -183,7 +183,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         sut.handleDeepLink(deepLink)
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: `default`)
     }
 
     func test_handles_product_listing_links() {
@@ -208,7 +208,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         sut.handleDeepLink(deepLink)
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: `default`)
     }
 
     func test_handles_product_details_links() {
@@ -223,7 +223,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         sut.handleDeepLink(deepLink)
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: `default`)
     }
 
     func test_handles_bag_links() {
@@ -237,7 +237,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         sut.handleDeepLink(deepLink)
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: `default`)
     }
 
     func test_handles_wishlist_links() {
@@ -251,7 +251,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         sut.handleDeepLink(deepLink)
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: `default`)
     }
 
     func test_handles_account_links() {
@@ -265,7 +265,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         sut.handleDeepLink(deepLink)
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: `default`)
     }
 
     func test_handles_but_ignores_unknown_links() {
@@ -279,7 +279,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         sut.handleDeepLink(deepLink)
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: inverted)
     }
 
     // MARK: - Pending links
@@ -298,7 +298,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         sut.handleDeepLink(deepLink)
-        wait(for: [notCalledExpectation], timeout: defaultTimeout)
+        wait(for: [notCalledExpectation], timeout: inverted)
 
         let calledExpectation = expectation(description: "wait for coordinator call")
         mockCoordinator.onNavigateToScreenCalled = { _ in
@@ -306,7 +306,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         mockCoordinator.isReadyForNavigation = true
-        wait(for: [calledExpectation], timeout: defaultTimeout)
+        wait(for: [calledExpectation], timeout: `default`)
     }
 
     func test_postpones_handling_web_links_until_it_becomes_ready() {
@@ -323,7 +323,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         sut.handleDeepLink(deepLink)
-        wait(for: [notCalledExpectation], timeout: defaultTimeout)
+        wait(for: [notCalledExpectation], timeout: inverted)
 
         let calledExpectation = expectation(description: "wait for coordinator call")
         mockCoordinator.onNavigateToScreenCalled = { screen in
@@ -332,7 +332,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         mockCoordinator.isReadyForNavigation = true
-        wait(for: [calledExpectation], timeout: defaultTimeout)
+        wait(for: [calledExpectation], timeout: `default`)
     }
 
     func test_can_handle_multiple_pending_links() {
@@ -358,13 +358,16 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         mockCoordinator.isReadyForNavigation = true
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: `default`)
     }
 
     // MARK: - Private
 
     private func createSut() {
-        sut = .init(configurationService: mockConfigurationService,
-                    coordinator: mockCoordinator)
+        sut = .init(
+            configurationService: mockConfigurationService,
+            coordinator: mockCoordinator,
+            scheduler: .immediate
+        )
     }
 }

--- a/Alfie/AlfieTests/Navigation/Deeplink/Handlers/DeepLinkHandlerTests.swift
+++ b/Alfie/AlfieTests/Navigation/Deeplink/Handlers/DeepLinkHandlerTests.swift
@@ -99,7 +99,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         sut.handleDeepLink(deepLink)
-        wait(for: [expectation], timeout: inverted)
+        wait(for: [expectation], timeout: .inverted)
     }
 
     func test_handles_home_links_when_ready() {
@@ -113,7 +113,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         sut.handleDeepLink(deepLink)
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
     }
 
     func test_handles_web_links_when_ready() {
@@ -127,7 +127,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         sut.handleDeepLink(deepLink)
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
     }
 
     func test_handles_shop_links_without_route() {
@@ -141,7 +141,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         sut.handleDeepLink(deepLink)
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
     }
 
     func test_handles_shop_links_with_shop_route() {
@@ -155,7 +155,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         sut.handleDeepLink(deepLink)
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
     }
 
     func test_handles_shop_links_with_brands_route() {
@@ -169,7 +169,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         sut.handleDeepLink(deepLink)
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
     }
 
     func test_handles_shop_links_with_services_route() {
@@ -183,7 +183,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         sut.handleDeepLink(deepLink)
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
     }
 
     func test_handles_product_listing_links() {
@@ -208,7 +208,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         sut.handleDeepLink(deepLink)
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
     }
 
     func test_handles_product_details_links() {
@@ -223,7 +223,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         sut.handleDeepLink(deepLink)
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
     }
 
     func test_handles_bag_links() {
@@ -237,7 +237,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         sut.handleDeepLink(deepLink)
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
     }
 
     func test_handles_wishlist_links() {
@@ -251,7 +251,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         sut.handleDeepLink(deepLink)
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
     }
 
     func test_handles_account_links() {
@@ -265,7 +265,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         sut.handleDeepLink(deepLink)
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
     }
 
     func test_handles_but_ignores_unknown_links() {
@@ -279,7 +279,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         sut.handleDeepLink(deepLink)
-        wait(for: [expectation], timeout: inverted)
+        wait(for: [expectation], timeout: .inverted)
     }
 
     // MARK: - Pending links
@@ -298,7 +298,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         sut.handleDeepLink(deepLink)
-        wait(for: [notCalledExpectation], timeout: inverted)
+        wait(for: [notCalledExpectation], timeout: .inverted)
 
         let calledExpectation = expectation(description: "wait for coordinator call")
         mockCoordinator.onNavigateToScreenCalled = { _ in
@@ -306,7 +306,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         mockCoordinator.isReadyForNavigation = true
-        wait(for: [calledExpectation], timeout: `default`)
+        wait(for: [calledExpectation])
     }
 
     func test_postpones_handling_web_links_until_it_becomes_ready() {
@@ -323,7 +323,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         sut.handleDeepLink(deepLink)
-        wait(for: [notCalledExpectation], timeout: inverted)
+        wait(for: [notCalledExpectation], timeout: .inverted)
 
         let calledExpectation = expectation(description: "wait for coordinator call")
         mockCoordinator.onNavigateToScreenCalled = { screen in
@@ -332,7 +332,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         mockCoordinator.isReadyForNavigation = true
-        wait(for: [calledExpectation], timeout: `default`)
+        wait(for: [calledExpectation])
     }
 
     func test_can_handle_multiple_pending_links() {
@@ -358,7 +358,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
 
         mockCoordinator.isReadyForNavigation = true
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
     }
 
     // MARK: - Private

--- a/Alfie/AlfieTests/Services/ApiEndpointServiceTests.swift
+++ b/Alfie/AlfieTests/Services/ApiEndpointServiceTests.swift
@@ -88,7 +88,7 @@ final class ApiEndpointServiceTests: XCTestCase {
 
         createSut()
         sut.updateApiEndpointAndReboot(.dev)
-        wait(for: [expectation], timeout: `default`)
+        wait(for: [expectation])
     }
 
     // MARK: - Private
@@ -98,7 +98,7 @@ final class ApiEndpointServiceTests: XCTestCase {
             appDelegate: mockAppDelegate,
             userDefaults: userDefaults,
             userDefaultsKey: Self.userDefaultsKey,
-            rebootDelay: inverted
+            rebootDelay: .inverted
         )
     }
 }

--- a/Alfie/AlfieTests/Services/ApiEndpointServiceTests.swift
+++ b/Alfie/AlfieTests/Services/ApiEndpointServiceTests.swift
@@ -88,7 +88,7 @@ final class ApiEndpointServiceTests: XCTestCase {
 
         createSut()
         sut.updateApiEndpointAndReboot(.dev)
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: .default)
     }
 
     // MARK: - Private

--- a/Alfie/AlfieTests/Services/ApiEndpointServiceTests.swift
+++ b/Alfie/AlfieTests/Services/ApiEndpointServiceTests.swift
@@ -88,15 +88,17 @@ final class ApiEndpointServiceTests: XCTestCase {
 
         createSut()
         sut.updateApiEndpointAndReboot(.dev)
-        wait(for: [expectation], timeout: defaultTimeout)
+        wait(for: [expectation], timeout: `default`)
     }
 
     // MARK: - Private
 
     private func createSut() {
-        sut = .init(appDelegate: mockAppDelegate,
-                    userDefaults: userDefaults,
-                    userDefaultsKey: Self.userDefaultsKey,
-                    rebootDelay: 0.5)
+        sut = .init(
+            appDelegate: mockAppDelegate,
+            userDefaults: userDefaults,
+            userDefaultsKey: Self.userDefaultsKey,
+            rebootDelay: inverted
+        )
     }
 }

--- a/Alfie/AlfieTests/Services/AppStartupServiceTests.swift
+++ b/Alfie/AlfieTests/Services/AppStartupServiceTests.swift
@@ -25,19 +25,32 @@ final class AppStartupServiceTests: XCTestCase {
     }
 
     func test_forceAppUpdateAvailable_currentScreen_appUpdateScreen() {
-        waitUntil(publisher: sut.$currentScreen.eraseToAnyPublisher(), emitsValue: .forceUpdate, asyncOperation: {
-            self.mockConfigurationService.isForceAppUpdateAvailable = true
-        }, timeout: defaultTimeout)
+        let currentScreen = XCTAssertEmitsValue(
+            from: sut.$currentScreen,
+            afterTrigger: { mockConfigurationService.isForceAppUpdateAvailable = true },
+            timeout: `default`
+        )
+
+        XCTAssertEqual(currentScreen, .forceUpdate)
     }
 
     func test_softAppUpdateAvailable_redirects_to_landing() {
-        waitUntil(publisher: sut.$currentScreen.eraseToAnyPublisher(), emitsValue: .landing, asyncOperation: {
-            self.mockConfigurationService.isSoftAppUpdateAvailable = true
-        }, timeout: defaultTimeout)
+        let currentScreen = XCTAssertEmitsValue(
+            from: sut.$currentScreen,
+            afterTrigger: { mockConfigurationService.isSoftAppUpdateAvailable = true },
+            timeout: `default`
+        )
+
+        XCTAssertEqual(currentScreen, .landing)
     }
 
     func test_currentScreen_is_eventually_landing() throws {
         //TODO: for now landing is set with a timer, this should be updated when we have actual loading of resources
-        waitUntil(publisher: sut.$currentScreen.eraseToAnyPublisher(), emitsValue: .landing, timeout: 3)
+        let currentScreen = XCTAssertEmitsValue(
+            from: sut.$currentScreen.drop(while: { $0 == .loading }),
+            timeout: `default`
+        )
+
+        XCTAssertEqual(currentScreen, .landing)
     }
 }

--- a/Alfie/AlfieTests/Services/AppStartupServiceTests.swift
+++ b/Alfie/AlfieTests/Services/AppStartupServiceTests.swift
@@ -11,7 +11,7 @@ final class AppStartupServiceTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
         mockConfigurationService = .init()
-        sut = .init(AppStartupService(configurationService: mockConfigurationService))
+        sut = .init(AppStartupService(configurationService: mockConfigurationService, startupCompletionDelay: 0))
     }
 
     override func tearDownWithError() throws {
@@ -25,32 +25,23 @@ final class AppStartupServiceTests: XCTestCase {
     }
 
     func test_forceAppUpdateAvailable_currentScreen_appUpdateScreen() {
-        let currentScreen = XCTAssertEmitsValue(
+        XCTAssertEmitsValueEqualTo(
             from: sut.$currentScreen,
-            afterTrigger: { mockConfigurationService.isForceAppUpdateAvailable = true },
-            timeout: `default`
+            expectedValue: .forceUpdate,
+            afterTrigger: { self.mockConfigurationService.isForceAppUpdateAvailable = true }
         )
-
-        XCTAssertEqual(currentScreen, .forceUpdate)
     }
 
     func test_softAppUpdateAvailable_redirects_to_landing() {
-        let currentScreen = XCTAssertEmitsValue(
+        XCTAssertEmitsValueEqualTo(
             from: sut.$currentScreen,
-            afterTrigger: { mockConfigurationService.isSoftAppUpdateAvailable = true },
-            timeout: `default`
+            expectedValue: .landing,
+            afterTrigger: { self.mockConfigurationService.isSoftAppUpdateAvailable = true }
         )
-
-        XCTAssertEqual(currentScreen, .landing)
     }
 
     func test_currentScreen_is_eventually_landing() throws {
         //TODO: for now landing is set with a timer, this should be updated when we have actual loading of resources
-        let currentScreen = XCTAssertEmitsValue(
-            from: sut.$currentScreen.drop(while: { $0 == .loading }),
-            timeout: `default`
-        )
-
-        XCTAssertEqual(currentScreen, .landing)
+        XCTAssertEmitsValueEqualTo(from: sut.$currentScreen.drop(while: { $0 == .loading }), expectedValue: .landing)
     }
 }

--- a/Alfie/AlfieTests/Services/RecentsServiceTests.swift
+++ b/Alfie/AlfieTests/Services/RecentsServiceTests.swift
@@ -32,25 +32,24 @@ final class RecentsServiceTests: XCTestCase {
     }
 
     func test_AddRecentSearchPublisher_ReturnsCorrectRecentSearches() {
-        waitUntil(
-            publisher: sut.recentSearchesPublisher,
-            emitsValue: [.recentSearch2, .recentSearch1],
-            asyncOperation: {
-                self.sut.add(.recentSearch1)
-                self.sut.add(.recentSearch2)
-            },
-            timeout: defaultTimeout)
+        sut.add(.recentSearch1)
+
+        let recents = XCTAssertEmitsValue(
+            from: sut.recentSearchesPublisher,
+            afterTrigger: { sut.add(.recentSearch2) }
+        )
+
+        XCTAssertEqual(recents, [.recentSearch2, .recentSearch1])
     }
 
     func test_AddRecentSearchPublisher_Repeated_DoesNOTAddToRecentSearches() {
-        waitUntil(
-            publisher: sut.recentSearchesPublisher,
-            emitsValue: [.recentSearch1],
-            asyncOperation: {
-                self.sut.add(.recentSearch1)
-                self.sut.add(.recentSearch1)
-            },
-            timeout: defaultTimeout)
+        sut.add(.recentSearch1)
+
+        XCTAssertNoEmit(
+            from: sut.recentSearchesPublisher,
+            afterTrigger: { sut.add(.recentSearch1) },
+            timeout: inverted
+        )
     }
 
     func test_AddRecentSearch_WithMaxItems_RemovesLastItem() {
@@ -82,7 +81,7 @@ final class RecentsServiceTests: XCTestCase {
 
         sut.add(.recentSearch1)
 
-        waitForExpectations(timeout: defaultTimeout)
+        waitForExpectations(timeout: `default`)
     }
 
     func test_RemoveRecentSearch_WhenEmptyRecentSearches_ReturnsEmptySearches() {
@@ -110,7 +109,7 @@ final class RecentsServiceTests: XCTestCase {
         sut.add(.recentSearch1)
         sut.remove(.recentSearch1)
 
-        waitForExpectations(timeout: defaultTimeout)
+        waitForExpectations(timeout: `default`)
     }
 
     func test_RemoveAll_ReturnsEmptySearches() {
@@ -134,7 +133,7 @@ final class RecentsServiceTests: XCTestCase {
         sut.add(.recentSearch2)
         sut.removeAll()
 
-        waitForExpectations(timeout: defaultTimeout)
+        waitForExpectations(timeout: `default`)
     }
 
     func test_Save_AddRecentSearch_SavesInStorage() {
@@ -148,7 +147,7 @@ final class RecentsServiceTests: XCTestCase {
                                  storageKey: "")
         sut.add(.recentSearch1)
         sut.save()
-        waitForExpectations(timeout: defaultTimeout)
+        waitForExpectations(timeout: `default`)
     }
 
     func test_Save_RemoveRecentSearch_SavesInStorage() {
@@ -163,7 +162,7 @@ final class RecentsServiceTests: XCTestCase {
         sut.add(.recentSearch1)
         sut.remove(.recentSearch1)
         sut.save()
-        waitForExpectations(timeout: defaultTimeout)
+        waitForExpectations(timeout: `default`)
     }
 
     func test_Save_WithOutOperation_DoesNOTSaveInStorage() {
@@ -177,6 +176,6 @@ final class RecentsServiceTests: XCTestCase {
                                  storageService: mockStorageService,
                                  storageKey: "")
         sut.save()
-        waitForExpectations(timeout: defaultTimeout)
+        waitForExpectations(timeout: inverted)
     }
 }

--- a/Alfie/AlfieTests/Services/RecentsServiceTests.swift
+++ b/Alfie/AlfieTests/Services/RecentsServiceTests.swift
@@ -36,7 +36,7 @@ final class RecentsServiceTests: XCTestCase {
 
         let recents = XCTAssertEmitsValue(
             from: sut.recentSearchesPublisher,
-            afterTrigger: { sut.add(.recentSearch2) }
+            afterTrigger: { self.sut.add(.recentSearch2) }
         )
 
         XCTAssertEqual(recents, [.recentSearch2, .recentSearch1])
@@ -45,11 +45,7 @@ final class RecentsServiceTests: XCTestCase {
     func test_AddRecentSearchPublisher_Repeated_DoesNOTAddToRecentSearches() {
         sut.add(.recentSearch1)
 
-        XCTAssertNoEmit(
-            from: sut.recentSearchesPublisher,
-            afterTrigger: { sut.add(.recentSearch1) },
-            timeout: inverted
-        )
+        XCTAssertNoEmit(from: sut.recentSearchesPublisher, afterTrigger: { self.sut.add(.recentSearch1) })
     }
 
     func test_AddRecentSearch_WithMaxItems_RemovesLastItem() {
@@ -81,7 +77,7 @@ final class RecentsServiceTests: XCTestCase {
 
         sut.add(.recentSearch1)
 
-        waitForExpectations(timeout: `default`)
+        waitForExpectations(timeout: .default)
     }
 
     func test_RemoveRecentSearch_WhenEmptyRecentSearches_ReturnsEmptySearches() {
@@ -109,7 +105,7 @@ final class RecentsServiceTests: XCTestCase {
         sut.add(.recentSearch1)
         sut.remove(.recentSearch1)
 
-        waitForExpectations(timeout: `default`)
+        waitForExpectations(timeout: .default)
     }
 
     func test_RemoveAll_ReturnsEmptySearches() {
@@ -133,7 +129,7 @@ final class RecentsServiceTests: XCTestCase {
         sut.add(.recentSearch2)
         sut.removeAll()
 
-        waitForExpectations(timeout: `default`)
+        waitForExpectations(timeout: .default)
     }
 
     func test_Save_AddRecentSearch_SavesInStorage() {
@@ -147,7 +143,7 @@ final class RecentsServiceTests: XCTestCase {
                                  storageKey: "")
         sut.add(.recentSearch1)
         sut.save()
-        waitForExpectations(timeout: `default`)
+        waitForExpectations(timeout: .default)
     }
 
     func test_Save_RemoveRecentSearch_SavesInStorage() {
@@ -162,7 +158,7 @@ final class RecentsServiceTests: XCTestCase {
         sut.add(.recentSearch1)
         sut.remove(.recentSearch1)
         sut.save()
-        waitForExpectations(timeout: `default`)
+        waitForExpectations(timeout: .default)
     }
 
     func test_Save_WithOutOperation_DoesNOTSaveInStorage() {
@@ -176,6 +172,6 @@ final class RecentsServiceTests: XCTestCase {
                                  storageService: mockStorageService,
                                  storageKey: "")
         sut.save()
-        waitForExpectations(timeout: inverted)
+        waitForExpectations(timeout: .inverted)
     }
 }


### PR DESCRIPTION
### Ticket

https://mindera.atlassian.net/browse/ALFMOB-141

### Description

Based on 10 test runs, i observed a **significant reduction** in execution times, now raging from **70.595s to 173.835s**, with an **average execution time of 109.860**, about **63.631s faster** than before.

To achieve this improvement, the follwoing optimizations were made:
- Reduced timeouts in tests where no events where expected.
- Optimized mocks to eliminate unnecessary delays.
- Integrated `CombineSchedulers` to better control threading in tests
- Fixed unit tests with false positives.
- Fixed unit tests that occasionally resulted in false negatives.