### PR TITLE
ALFMOB-151: Sync Sign In / Sign Out buttons state

### DIFF
--- a/Alfie/Alfie/Helpers/ToolbarItemProvider.swift
+++ b/Alfie/Alfie/Helpers/ToolbarItemProvider.swift
@@ -106,17 +106,15 @@ enum ToolbarItemProvider {
     public static func trailingItems(
         for screen: Screen,
         coordinator: Coordinator,
-        isWishlistEnabled: Bool,
-        isPresentingDebugMenu: Binding<Bool>? = nil
+        isWishlistEnabled: Bool
     ) -> some ToolbarContent {
         ToolbarItemGroup(placement: .topBarTrailing) {
             switch screen {
             case .tab(let tab):
                 switch tab {
                 case .home:
-                    if let isPresentingDebugMenu {
-                        debugMenuItem(isPresentingDebugMenu, size: .big)
-                    }
+                    // TODO: Remove debug menu for production releases
+                    debugMenuItem(with: coordinator, size: .big)
                     accountItem(with: coordinator, size: .big)
 
                 case .shop,
@@ -207,11 +205,11 @@ enum ToolbarItemProvider {
     }
 
     private static func debugMenuItem(
-        _ isPresentingDebugMenu: Binding<Bool>,
+        with coordinator: Coordinator,
         size: ToolBarButtonSize = .normal
     ) -> some View {
         ThemedToolbarButton(icon: .settings, accessibilityId: AccessibilityId.settingsBtn, toolBarButtonSize: size) {
-            isPresentingDebugMenu.wrappedValue = true
+            coordinator.openDebugMenu()
         }
     }
 

--- a/Alfie/Alfie/Modifiers/DefaultToolbarModifier.swift
+++ b/Alfie/Alfie/Modifiers/DefaultToolbarModifier.swift
@@ -27,8 +27,7 @@ struct DefaultToolbarModifier: ViewModifier {
                 ToolbarItemProvider.trailingItems(
                     for: screen,
                     coordinator: coordinator,
-                    isWishlistEnabled: coordinator.isWishlistEnabled,
-                    isPresentingDebugMenu: $coordinator.isPresentingDebugMenu
+                    isWishlistEnabled: coordinator.isWishlistEnabled
                 )
             }
             .modifier(ThemedToolbarModifier(showDivider: hasDivider))

--- a/Alfie/Alfie/Navigation/Coordinator.swift
+++ b/Alfie/Alfie/Navigation/Coordinator.swift
@@ -6,7 +6,6 @@ import UIKit
 final class Coordinator: ObservableObject, CoordinatorProtocol {
     let navigationAdapter: NavigationAdapter<Screen>
     let isWishlistEnabled: Bool
-    @Published var isPresentingDebugMenu = false
 
     init(navigationAdapter: NavigationAdapter<Screen>, isWishlistEnabled: Bool) {
         self.navigationAdapter = navigationAdapter

--- a/Alfie/Alfie/Navigation/ViewFactory.swift
+++ b/Alfie/Alfie/Navigation/ViewFactory.swift
@@ -23,7 +23,7 @@ final class ViewFactory: ViewFactoryProtocol {
         case .tab(let tab):
             switch tab {
             case .home:
-                HomeView(viewFactory: self, analytics: serviceProvider.analytics)
+                HomeView(viewModel: HomeViewModel(sessionService: serviceProvider.sessionService))
 
             case .shop:
                 ShopView(
@@ -57,7 +57,12 @@ final class ViewFactory: ViewFactoryProtocol {
             }
 
         case .account:
-            AccountView(viewModel: AccountViewModel(configurationService: serviceProvider.configurationService))
+            AccountView(
+                viewModel: AccountViewModel(
+                    configurationService: serviceProvider.configurationService,
+                    sessionService: serviceProvider.sessionService
+                )
+            )
 
         case .search(let transition):
             let dependencies = SearchDependencyContainer(

--- a/Alfie/Alfie/Service/ServiceProvider.swift
+++ b/Alfie/Alfie/Service/ServiceProvider.swift
@@ -27,6 +27,7 @@ final class ServiceProvider: ServiceProviderProtocol {
     let webViewConfigurationService: WebViewConfigurationServiceProtocol
     let bagService: BagServiceProtocol
     let wishlistService: WishlistServiceProtocol
+    let sessionService: SessionServiceProtocol
 
     private(set) var authenticationService: AuthenticationServiceProtocol
 
@@ -93,6 +94,7 @@ final class ServiceProvider: ServiceProviderProtocol {
         webViewConfigurationService = WebViewConfigurationService(bffClient: bffClient, log: log)
         bagService = BagService()
         wishlistService = WishlistService()
+        sessionService = SessionService(analytics: analytics)
     }
 
     public func resetServices() {

--- a/Alfie/Alfie/Views/AccountView/AccountSection.swift
+++ b/Alfie/Alfie/Views/AccountView/AccountSection.swift
@@ -3,45 +3,50 @@ import StyleGuide
 // MARK: - AccountSection
 
 enum AccountSection: CaseIterable {
+    case myAddressBook
     case myDetails
     case myOrders
-    case wallet
-    case myAddressBook
-    case wishlist
+    case signIn
     case signOut
+    case wallet
+    case wishlist
 
     var title: String {
         switch self {
+        case .myAddressBook:
+            "My Address Book"
         case .myDetails:
             "My Details"
         case .myOrders:
             "My Orders"
-        case .wallet:
-            "Wallet"
-        case .myAddressBook:
-            "My Address Book"
-        case .wishlist:
-            "Wishlist"
+        case .signIn:
+            "Sign In"
         case .signOut:
             "Sign Out"
+        case .wallet:
+            "Wallet"
+        case .wishlist:
+            "Wishlist"
         }
     }
 
     var icon: Icon {
         // swiftlint:disable vertical_whitespace_between_cases
         switch self {
+        case .myAddressBook:
+            Icon.location
         case .myDetails:
             Icon.user
         case .myOrders:
             Icon.store
-        case .wallet:
-            Icon.chat2
-        case .myAddressBook:
-            Icon.location
-        case .wishlist:
-            Icon.heart
+        case .signIn:
+            Icon.logIn
         case .signOut:
             Icon.logOut
+        case .wallet:
+            Icon.chat2
+        case .wishlist:
+            Icon.heart
         }
         // swiftlint:enable vertical_whitespace_between_cases
     }

--- a/Alfie/Alfie/Views/AccountView/AccountView.swift
+++ b/Alfie/Alfie/Views/AccountView/AccountView.swift
@@ -38,11 +38,17 @@ struct AccountView<ViewModel: AccountViewModelProtocol>: View {
         switch section {
         case .wishlist:
             coordinator.openWishlist()
+
+        case .signIn:
+            viewModel.didTapSignIn()
+
+        case .signOut:
+            viewModel.didTapSignOut()
+
         case .myAddressBook,
              .myDetails, // swiftlint:disable:this indentation_width
              .myOrders,
-             .wallet,
-             .signOut:
+             .wallet:
             // TODO: Implement in a future ticket
             break
         }
@@ -50,30 +56,33 @@ struct AccountView<ViewModel: AccountViewModelProtocol>: View {
 }
 
 private enum AccessibilityId {
+    static let addressBookSection = "address-book-section"
     static let myDetailsSection = "my-details-section"
     static let myOrdersSection = "my-orders-section"
-    static let walletSection = "wallet-section"
-    static let addressBookSection = "address-book-section"
-    static let wishlistSection = "wishlist-section"
+    static let signInSection = "sign-in-section"
     static let signOutSection = "sign-out-section"
+    static let walletSection = "wallet-section"
+    static let wishlistSection = "wishlist-section"
 }
 
 private extension AccountSection {
     var accessibilityId: String {
         // swiftlint:disable vertical_whitespace_between_cases
         switch self {
+        case .myAddressBook:
+            AccessibilityId.addressBookSection
         case .myDetails:
             AccessibilityId.myDetailsSection
         case .myOrders:
             AccessibilityId.myOrdersSection
-        case .wallet:
-            AccessibilityId.walletSection
-        case .myAddressBook:
-            AccessibilityId.addressBookSection
-        case .wishlist:
-            AccessibilityId.wishlistSection
+        case .signIn:
+            AccessibilityId.signInSection
         case .signOut:
             AccessibilityId.signOutSection
+        case .wallet:
+            AccessibilityId.walletSection
+        case .wishlist:
+            AccessibilityId.wishlistSection
         }
         // swiftlint:enable vertical_whitespace_between_cases
     }
@@ -81,7 +90,12 @@ private extension AccountSection {
 
 #if DEBUG
 #Preview {
-    AccountView(viewModel: AccountViewModel(configurationService: MockConfigurationService()))
-        .environmentObject(Coordinator())
+    AccountView(
+        viewModel: AccountViewModel(
+            configurationService: MockConfigurationService(),
+            sessionService: MockSessionService()
+        )
+    )
+    .environmentObject(Coordinator())
 }
 #endif

--- a/Alfie/Alfie/Views/AccountView/AccountViewModel.swift
+++ b/Alfie/Alfie/Views/AccountView/AccountViewModel.swift
@@ -30,17 +30,17 @@ final class AccountViewModel: AccountViewModelProtocol {
     private func setupBindings() {
         Publishers.CombineLatest(
             configurationService.featureAvailabilityPublisher,
-            sessionService.isUserSignInPublisher
+            sessionService.isUserSignedInPublisher
         )
-        .sink { [weak self] _, isUserSignIn in
+        .sink { [weak self] featureAvailability, isUserSignedIn in
             guard let self else { return }
             sectionList = [
                 .myDetails,
                 .myOrders,
                 .wallet,
                 .myAddressBook,
-                configurationService.isFeatureEnabled(.wishlist) ? .wishlist : nil,
-                isUserSignIn ? .signOut : .signIn,
+                featureAvailability[.wishlist] != nil ? .wishlist : nil,
+                isUserSignedIn ? .signOut : .signIn,
             ]
             .compactMap { $0 }
         }
@@ -48,10 +48,10 @@ final class AccountViewModel: AccountViewModelProtocol {
     }
 
     func didTapSignIn() {
-        sessionService.loginUser()
+        sessionService.signInUser()
     }
 
     func didTapSignOut() {
-        sessionService.logoutUser()
+        sessionService.signOutUser()
     }
 }

--- a/Alfie/Alfie/Views/AccountView/AccountViewModel.swift
+++ b/Alfie/Alfie/Views/AccountView/AccountViewModel.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import Models
 import StyleGuide
@@ -6,22 +7,58 @@ import StyleGuide
 
 protocol AccountViewModelProtocol: ObservableObject {
     var sectionList: [AccountSection] { get }
+
+    func didTapSignIn()
+    func didTapSignOut()
 }
 
 // MARK: - AccountViewModel
 
 final class AccountViewModel: AccountViewModelProtocol {
-    private(set) var sectionList: [AccountSection]
+    // MARK: Properties
 
     private let configurationService: ConfigurationServiceProtocol
+    private let sessionService: SessionServiceProtocol
+    private var subscriptions: Set<AnyCancellable> = []
 
-    init(configurationService: ConfigurationServiceProtocol) {
+    // MARK: Lifecycle
+
+    init(configurationService: ConfigurationServiceProtocol, sessionService: SessionServiceProtocol) {
         self.configurationService = configurationService
-        let isWishlistEnabled = configurationService.isFeatureEnabled(.wishlist)
+        self.sessionService = sessionService
 
-        sectionList = [.myDetails, .myOrders, .wallet, .myAddressBook, .signOut]
-        if isWishlistEnabled {
-            sectionList.insert(.wishlist, at: 4)
+        setupBindings()
+    }
+
+    private func setupBindings() {
+        Publishers.CombineLatest(
+            configurationService.featureAvailabilityPublisher,
+            sessionService.isUserLoggedPublisher
+        )
+        .sink { [weak self] _, isUserLogged in
+            guard let self else { return }
+            sectionList = [
+                .myDetails,
+                .myOrders,
+                .wallet,
+                .myAddressBook,
+                configurationService.isFeatureEnabled(.wishlist) ? .wishlist : nil,
+                isUserLogged ? .signOut : .signIn,
+            ]
+            .compactMap { $0 }
         }
+        .store(in: &subscriptions)
+    }
+
+    // MARK: AccountViewModelProtocol
+
+    @Published private(set) var sectionList: [AccountSection] = []
+
+    func didTapSignIn() {
+        sessionService.loginUser()
+    }
+
+    func didTapSignOut() {
+        sessionService.logoutUser()
     }
 }

--- a/Alfie/Alfie/Views/AccountView/AccountViewModel.swift
+++ b/Alfie/Alfie/Views/AccountView/AccountViewModel.swift
@@ -30,9 +30,9 @@ final class AccountViewModel: AccountViewModelProtocol {
     private func setupBindings() {
         Publishers.CombineLatest(
             configurationService.featureAvailabilityPublisher,
-            sessionService.isUserLoggedPublisher
+            sessionService.isUserSignInPublisher
         )
-        .sink { [weak self] _, isUserLogged in
+        .sink { [weak self] _, isUserSignIn in
             guard let self else { return }
             sectionList = [
                 .myDetails,
@@ -40,7 +40,7 @@ final class AccountViewModel: AccountViewModelProtocol {
                 .wallet,
                 .myAddressBook,
                 configurationService.isFeatureEnabled(.wishlist) ? .wishlist : nil,
-                isUserLogged ? .signOut : .signIn,
+                isUserSignIn ? .signOut : .signIn,
             ]
             .compactMap { $0 }
         }

--- a/Alfie/Alfie/Views/AccountView/AccountViewModel.swift
+++ b/Alfie/Alfie/Views/AccountView/AccountViewModel.swift
@@ -15,13 +15,10 @@ protocol AccountViewModelProtocol: ObservableObject {
 // MARK: - AccountViewModel
 
 final class AccountViewModel: AccountViewModelProtocol {
-    // MARK: Properties
-
     private let configurationService: ConfigurationServiceProtocol
     private let sessionService: SessionServiceProtocol
     private var subscriptions: Set<AnyCancellable> = []
-
-    // MARK: Lifecycle
+    @Published private(set) var sectionList: [AccountSection] = []
 
     init(configurationService: ConfigurationServiceProtocol, sessionService: SessionServiceProtocol) {
         self.configurationService = configurationService
@@ -49,10 +46,6 @@ final class AccountViewModel: AccountViewModelProtocol {
         }
         .store(in: &subscriptions)
     }
-
-    // MARK: AccountViewModelProtocol
-
-    @Published private(set) var sectionList: [AccountSection] = []
 
     func didTapSignIn() {
         sessionService.loginUser()

--- a/Alfie/Alfie/Views/BagView/BagView.swift
+++ b/Alfie/Alfie/Views/BagView/BagView.swift
@@ -39,11 +39,10 @@ struct BagView<ViewModel: BagViewModelProtocol>: View {
 #if DEBUG
 #Preview {
     BagView(
-        viewModel: BagViewModel(
-            dependencies: BagDependencyContainer(
-                bagService: MockBagService(),
-                analytics: MockAnalyticsTracker().eraseToAnyAnalyticsTracker()
-            )
+        viewModel: MockBagViewModel(
+            products: [
+                .init(product: Product.fixture())
+            ]
         )
     )
     .environmentObject(Coordinator())

--- a/Alfie/Alfie/Views/HomeView/HomeView.swift
+++ b/Alfie/Alfie/Views/HomeView/HomeView.swift
@@ -60,17 +60,9 @@ struct HomeView<ViewModel: HomeViewModelProtocol>: View {
 private extension View {
     func toolbarView(username: String?, memberSince: Int?) -> some View {
         if let username, let memberSince {
-            withToolbar(
-                for: .tab(
-                    .home(.loggedIn(username: username, memberSince: memberSince))
-                )
-            )
+            withToolbar(for: .tab(.home(.loggedIn(username: username, memberSince: memberSince))))
         } else {
-            withToolbar(
-                for: .tab(
-                    .home(.loggedOut)
-                )
-            )
+            withToolbar(for: .tab(.home(.loggedOut)))
         }
     }
 }

--- a/Alfie/Alfie/Views/HomeView/HomeView.swift
+++ b/Alfie/Alfie/Views/HomeView/HomeView.swift
@@ -6,17 +6,14 @@ import SwiftUI
 import Mocks
 #endif
 
-struct HomeView: View {
+struct HomeView<ViewModel: HomeViewModelProtocol>: View {
     @EnvironmentObject var coordinador: Coordinator
-    private let viewFactory: ViewFactory?
+    @StateObject private var viewModel: ViewModel
     @State private var showSearchBar = true
-    @State private var isUserLogged = false
     @Namespace private var animation
-    private let analytics: AlfieAnalyticsTracker
 
-    init(viewFactory: ViewFactory? = nil, analytics: AlfieAnalyticsTracker) {
-        self.viewFactory = viewFactory
-        self.analytics = analytics
+    init(viewModel: ViewModel) {
+        _viewModel = StateObject(wrappedValue: viewModel)
     }
 
     var body: some View {
@@ -49,22 +46,31 @@ struct HomeView: View {
                 .resizable()
                 .scaledToFit()
                 .frame(width: 75)
-            Text.build(theme.font.header.h3(L10n.Home.title))
-            ThemedButton(text: isUserLogged ? L10n.Home.SignOut.Button.cta : L10n.Home.SignIn.Button.cta) {
-                isUserLogged.toggle()
-                analytics.trackUser(isLoggedIn: isUserLogged)
+            Text.build(theme.font.header.h3(viewModel.homeTitle))
+            ThemedButton(text: viewModel.signInButtonText) {
+                viewModel.didTapSignInButton()
             }
             Spacer()
         }
-        .withToolbar(
-            for: .tab(
-                .home(isUserLogged ? .loggedIn(username: "Alfie", memberSince: 2024) : .loggedOut)
-            )
-        )
+        .toolbarView(username: viewModel.username, memberSince: viewModel.memberSince)
         .ignoresSafeArea(.keyboard, edges: .bottom)
-        // TODO: Remove debug menu for production releases
-        .fullScreenCover(isPresented: $coordinador.isPresentingDebugMenu) {
-            viewFactory?.view(for: .debugMenu)
+    }
+}
+
+private extension View {
+    func toolbarView(username: String?, memberSince: Int?) -> some View {
+        if let username, let memberSince {
+            withToolbar(
+                for: .tab(
+                    .home(.loggedIn(username: username, memberSince: memberSince))
+                )
+            )
+        } else {
+            withToolbar(
+                for: .tab(
+                    .home(.loggedOut)
+                )
+            )
         }
     }
 }
@@ -77,7 +83,7 @@ private enum Constants {
 
 #if DEBUG
 #Preview {
-    HomeView(analytics: MockAnalyticsTracker().eraseToAnyAnalyticsTracker())
+    HomeView(viewModel: MockHomeViewModel())
         .environmentObject(Coordinator())
 }
 #endif

--- a/Alfie/Alfie/Views/HomeView/HomeViewModel.swift
+++ b/Alfie/Alfie/Views/HomeView/HomeViewModel.swift
@@ -4,7 +4,7 @@ import SwiftUI
 
 public class HomeViewModel: HomeViewModelProtocol {
     private let sessionService: SessionServiceProtocol
-    @Published private var isUserLogged = false
+    @Published private var isUserSignIn = false
     private var subscriptions: Set<AnyCancellable> = []
 
     public var homeTitle: String {
@@ -12,15 +12,15 @@ public class HomeViewModel: HomeViewModelProtocol {
     }
 
     public var signInButtonText: String {
-        isUserLogged ? L10n.Home.SignOut.Button.cta : L10n.Home.SignIn.Button.cta
+        isUserSignIn ? L10n.Home.SignOut.Button.cta : L10n.Home.SignIn.Button.cta
     }
 
     public var username: String? {
-        isUserLogged ? "Alfie" : nil
+        isUserSignIn ? "Alfie" : nil
     }
 
     public var memberSince: Int? {
-        isUserLogged ? 2024 : nil
+        isUserSignIn ? 2024 : nil
     }
 
     init(sessionService: SessionServiceProtocol) {
@@ -30,13 +30,13 @@ public class HomeViewModel: HomeViewModelProtocol {
     }
 
     private func setupBindings() {
-        sessionService.isUserLoggedPublisher
-            .assignWeakly(to: \.isUserLogged, on: self)
+        sessionService.isUserSignInPublisher
+            .assignWeakly(to: \.isUserSignIn, on: self)
             .store(in: &subscriptions)
     }
 
     public func didTapSignInButton() {
-        if isUserLogged {
+        if isUserSignIn {
             sessionService.logoutUser()
         } else {
             sessionService.loginUser()

--- a/Alfie/Alfie/Views/HomeView/HomeViewModel.swift
+++ b/Alfie/Alfie/Views/HomeView/HomeViewModel.swift
@@ -1,0 +1,51 @@
+import Combine
+import Models
+import SwiftUI
+
+public class HomeViewModel: HomeViewModelProtocol {
+    // MARK: Properties
+
+    private let sessionService: SessionServiceProtocol
+    @Published private var isUserLogged = false
+    private var subscriptions: Set<AnyCancellable> = []
+
+    // MARK: Lifecycle
+
+    init(sessionService: SessionServiceProtocol) {
+        self.sessionService = sessionService
+
+        setupBindings()
+    }
+
+    private func setupBindings() {
+        sessionService.isUserLoggedPublisher
+            .assignWeakly(to: \.isUserLogged, on: self)
+            .store(in: &subscriptions)
+    }
+
+    // MARK: HomeViewModelProtocol
+
+    public var homeTitle: String {
+        L10n.Home.title
+    }
+
+    public var signInButtonText: String {
+        isUserLogged ? L10n.Home.SignOut.Button.cta : L10n.Home.SignIn.Button.cta
+    }
+
+    public var username: String? {
+        isUserLogged ? "Alfie" : nil
+    }
+
+    public var memberSince: Int? {
+        isUserLogged ? 2024 : nil
+    }
+
+    public func didTapSignInButton() {
+        if isUserLogged {
+            sessionService.logoutUser()
+        } else {
+            sessionService.loginUser()
+        }
+    }
+}

--- a/Alfie/Alfie/Views/HomeView/HomeViewModel.swift
+++ b/Alfie/Alfie/Views/HomeView/HomeViewModel.swift
@@ -3,27 +3,9 @@ import Models
 import SwiftUI
 
 public class HomeViewModel: HomeViewModelProtocol {
-    // MARK: Properties
-
     private let sessionService: SessionServiceProtocol
     @Published private var isUserLogged = false
     private var subscriptions: Set<AnyCancellable> = []
-
-    // MARK: Lifecycle
-
-    init(sessionService: SessionServiceProtocol) {
-        self.sessionService = sessionService
-
-        setupBindings()
-    }
-
-    private func setupBindings() {
-        sessionService.isUserLoggedPublisher
-            .assignWeakly(to: \.isUserLogged, on: self)
-            .store(in: &subscriptions)
-    }
-
-    // MARK: HomeViewModelProtocol
 
     public var homeTitle: String {
         L10n.Home.title
@@ -39,6 +21,18 @@ public class HomeViewModel: HomeViewModelProtocol {
 
     public var memberSince: Int? {
         isUserLogged ? 2024 : nil
+    }
+
+    init(sessionService: SessionServiceProtocol) {
+        self.sessionService = sessionService
+
+        setupBindings()
+    }
+
+    private func setupBindings() {
+        sessionService.isUserLoggedPublisher
+            .assignWeakly(to: \.isUserLogged, on: self)
+            .store(in: &subscriptions)
     }
 
     public func didTapSignInButton() {

--- a/Alfie/Alfie/Views/HomeView/HomeViewModel.swift
+++ b/Alfie/Alfie/Views/HomeView/HomeViewModel.swift
@@ -4,7 +4,7 @@ import SwiftUI
 
 public class HomeViewModel: HomeViewModelProtocol {
     private let sessionService: SessionServiceProtocol
-    @Published private var isUserSignIn = false
+    @Published private var isUserSignedIn = false
     private var subscriptions: Set<AnyCancellable> = []
 
     public var homeTitle: String {
@@ -12,15 +12,15 @@ public class HomeViewModel: HomeViewModelProtocol {
     }
 
     public var signInButtonText: String {
-        isUserSignIn ? L10n.Home.SignOut.Button.cta : L10n.Home.SignIn.Button.cta
+        isUserSignedIn ? L10n.Home.SignOut.Button.cta : L10n.Home.SignIn.Button.cta
     }
 
     public var username: String? {
-        isUserSignIn ? "Alfie" : nil
+        isUserSignedIn ? "Alfie" : nil
     }
 
     public var memberSince: Int? {
-        isUserSignIn ? 2024 : nil
+        isUserSignedIn ? 2024 : nil
     }
 
     init(sessionService: SessionServiceProtocol) {
@@ -30,16 +30,16 @@ public class HomeViewModel: HomeViewModelProtocol {
     }
 
     private func setupBindings() {
-        sessionService.isUserSignInPublisher
-            .assignWeakly(to: \.isUserSignIn, on: self)
+        sessionService.isUserSignedInPublisher
+            .assignWeakly(to: \.isUserSignedIn, on: self)
             .store(in: &subscriptions)
     }
 
     public func didTapSignInButton() {
-        if isUserSignIn {
-            sessionService.logoutUser()
+        if isUserSignedIn {
+            sessionService.signOutUser()
         } else {
-            sessionService.loginUser()
+            sessionService.signInUser()
         }
     }
 }

--- a/Alfie/AlfieKit/Sources/Core/Services/Analytics/AlfieAnalyticsTracker+Extensions.swift
+++ b/Alfie/AlfieKit/Sources/Core/Services/Analytics/AlfieAnalyticsTracker+Extensions.swift
@@ -26,7 +26,7 @@ public extension AlfieAnalyticsTracker {
 
     // MARK: - State Events
 
-    func trackUser(isSignIn: Bool) {
-        track(.state(.isUserSignIn(isSignIn), nil))
+    func trackUser(isSignedIn: Bool) {
+        track(.state(.isUserSignedIn(isSignedIn), nil))
     }
 }

--- a/Alfie/AlfieKit/Sources/Core/Services/Analytics/AlfieAnalyticsTracker+Extensions.swift
+++ b/Alfie/AlfieKit/Sources/Core/Services/Analytics/AlfieAnalyticsTracker+Extensions.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Models
 
-extension AlfieAnalyticsTracker {
+public extension AlfieAnalyticsTracker {
     // MARK: - Action Events
 
     func trackAddToBag(productID: String) {

--- a/Alfie/AlfieKit/Sources/Core/Services/Analytics/AlfieAnalyticsTracker+Extensions.swift
+++ b/Alfie/AlfieKit/Sources/Core/Services/Analytics/AlfieAnalyticsTracker+Extensions.swift
@@ -26,7 +26,7 @@ public extension AlfieAnalyticsTracker {
 
     // MARK: - State Events
 
-    func trackUser(isLoggedIn: Bool) {
-        track(.state(.isUserLoggedIn(isLoggedIn), nil))
+    func trackUser(isSignIn: Bool) {
+        track(.state(.isUserSignIn(isSignIn), nil))
     }
 }

--- a/Alfie/AlfieKit/Sources/Core/Services/Session/SessionService.swift
+++ b/Alfie/AlfieKit/Sources/Core/Services/Session/SessionService.swift
@@ -4,16 +4,16 @@ import Models
 
 // TODO: Update with an actual implementation with network APIs
 public final class SessionService: SessionServiceProtocol {
-    public var isUserSignInPublisher: AnyPublisher<Bool, Never> {
-        $isUserLogged.eraseToAnyPublisher()
+    public var isUserSignedInPublisher: AnyPublisher<Bool, Never> {
+        $isUserSignedIn.eraseToAnyPublisher()
     }
 
-    @Published private var isUserLogged: Bool
+    @Published private var isUserSignedIn: Bool
     private let analytics: AlfieAnalyticsTracker
     private var subscriptions: Set<AnyCancellable> = []
 
     public init(analytics: AlfieAnalyticsTracker) {
-        self.isUserLogged = false
+        self.isUserSignedIn = false
         self.analytics = analytics
 
         setupBindings()
@@ -21,20 +21,20 @@ public final class SessionService: SessionServiceProtocol {
 
     private func setupBindings() {
         // TODO: Analytics shouldn't be part of Services, this should have a more generic handle like an AppViewModel
-        isUserSignInPublisher
+        isUserSignedInPublisher
             .dropFirst()
-            .sink { [weak self] isUserSignIn in
+            .sink { [weak self] isUserSignedIn in
                 guard let self else { return }
-                analytics.trackUser(isSignIn: isUserSignIn)
+                analytics.trackUser(isSignedIn: isUserSignedIn)
             }
             .store(in: &subscriptions)
     }
 
-    public func loginUser() {
-        isUserLogged = true
+    public func signInUser() {
+        isUserSignedIn = true
     }
 
-    public func logoutUser() {
-        isUserLogged = false
+    public func signOutUser() {
+        isUserSignedIn = false
     }
 }

--- a/Alfie/AlfieKit/Sources/Core/Services/Session/SessionService.swift
+++ b/Alfie/AlfieKit/Sources/Core/Services/Session/SessionService.swift
@@ -4,7 +4,7 @@ import Models
 
 // TODO: Update with an actual implementation with network APIs
 public final class SessionService: SessionServiceProtocol {
-    public var isUserLoggedPublisher: AnyPublisher<Bool, Never> {
+    public var isUserSignInPublisher: AnyPublisher<Bool, Never> {
         $isUserLogged.eraseToAnyPublisher()
     }
 
@@ -21,11 +21,11 @@ public final class SessionService: SessionServiceProtocol {
 
     private func setupBindings() {
         // TODO: Analytics shouldn't be part of Services, this should have a more generic handle like an AppViewModel
-        isUserLoggedPublisher
+        isUserSignInPublisher
             .dropFirst()
-            .sink { [weak self] isUserLogged in
+            .sink { [weak self] isUserSignIn in
                 guard let self else { return }
-                analytics.trackUser(isLoggedIn: isUserLogged)
+                analytics.trackUser(isSignIn: isUserSignIn)
             }
             .store(in: &subscriptions)
     }

--- a/Alfie/AlfieKit/Sources/Core/Services/Session/SessionService.swift
+++ b/Alfie/AlfieKit/Sources/Core/Services/Session/SessionService.swift
@@ -1,0 +1,44 @@
+import Combine
+import Foundation
+import Models
+
+// TODO: Update with an actual implementation with network APIs
+public final class SessionService: SessionServiceProtocol {
+    // MARK: SessionServiceProtocol
+
+    public var isUserLoggedPublisher: AnyPublisher<Bool, Never> {
+        $isUserLogged.eraseToAnyPublisher()
+    }
+
+    public func loginUser() {
+        isUserLogged = true
+    }
+
+    public func logoutUser() {
+        isUserLogged = false
+    }
+
+    // MARK: Lifecycle
+
+    @Published private var isUserLogged: Bool
+    private let analytics: AlfieAnalyticsTracker
+    private var subscriptions: Set<AnyCancellable> = []
+
+    public init(analytics: AlfieAnalyticsTracker) {
+        self.isUserLogged = false
+        self.analytics = analytics
+
+        setupBindings()
+    }
+
+    private func setupBindings() {
+        // TODO: Analytics shouldn't be part of Services, this should have a more generic handle like an AppViewModel
+        isUserLoggedPublisher
+            .dropFirst()
+            .sink { [weak self] isUserLogged in
+                guard let self else { return }
+                analytics.trackUser(isLoggedIn: isUserLogged)
+            }
+            .store(in: &subscriptions)
+    }
+}

--- a/Alfie/AlfieKit/Sources/Core/Services/Session/SessionService.swift
+++ b/Alfie/AlfieKit/Sources/Core/Services/Session/SessionService.swift
@@ -4,21 +4,9 @@ import Models
 
 // TODO: Update with an actual implementation with network APIs
 public final class SessionService: SessionServiceProtocol {
-    // MARK: SessionServiceProtocol
-
     public var isUserLoggedPublisher: AnyPublisher<Bool, Never> {
         $isUserLogged.eraseToAnyPublisher()
     }
-
-    public func loginUser() {
-        isUserLogged = true
-    }
-
-    public func logoutUser() {
-        isUserLogged = false
-    }
-
-    // MARK: Lifecycle
 
     @Published private var isUserLogged: Bool
     private let analytics: AlfieAnalyticsTracker
@@ -40,5 +28,13 @@ public final class SessionService: SessionServiceProtocol {
                 analytics.trackUser(isLoggedIn: isUserLogged)
             }
             .store(in: &subscriptions)
+    }
+
+    public func loginUser() {
+        isUserLogged = true
+    }
+
+    public func logoutUser() {
+        isUserLogged = false
     }
 }

--- a/Alfie/AlfieKit/Sources/Mocks/Core/Features/MockHomeViewModel.swift
+++ b/Alfie/AlfieKit/Sources/Mocks/Core/Features/MockHomeViewModel.swift
@@ -2,10 +2,10 @@ import Foundation
 import Models
 
 public class MockHomeViewModel: HomeViewModelProtocol {
-    public var homeTitle: String { "Home" }
-    public var signInButtonText: String { "Sign in" }
-    public var username: String? { nil }
-    public var memberSince: Int? { nil }
+    public var homeTitle: String = "Home"
+    public var signInButtonText: String = "Sign in"
+    public var username: String?
+    public var memberSince: Int?
 
     public var onDidTapSignInButtonCalled: (() -> Void)?
     public func didTapSignInButton() {

--- a/Alfie/AlfieKit/Sources/Mocks/Core/Features/MockHomeViewModel.swift
+++ b/Alfie/AlfieKit/Sources/Mocks/Core/Features/MockHomeViewModel.swift
@@ -1,0 +1,16 @@
+import Foundation
+import Models
+
+public class MockHomeViewModel: HomeViewModelProtocol {
+    public var homeTitle: String { "Home" }
+    public var signInButtonText: String { "Sign in" }
+    public var username: String? { nil }
+    public var memberSince: Int? { nil }
+
+    public var onDidTapSignInButtonCalled: (() -> Void)?
+    public func didTapSignInButton() {
+        onDidTapSignInButtonCalled?()
+    }
+
+    public init() { }
+}

--- a/Alfie/AlfieKit/Sources/Mocks/Core/Services/MockServiceProvider.swift
+++ b/Alfie/AlfieKit/Sources/Mocks/Core/Services/MockServiceProvider.swift
@@ -23,6 +23,7 @@ public final class MockServiceProvider: ServiceProviderProtocol {
     public var webViewConfigurationService: WebViewConfigurationServiceProtocol
     public var bagService: BagServiceProtocol
     public var wishlistService: WishlistServiceProtocol
+    public var sessionService: SessionServiceProtocol
 
     public init(
         analytics: AlfieAnalyticsTracker = MockAnalyticsTracker().eraseToAnyAnalyticsTracker(),
@@ -43,7 +44,8 @@ public final class MockServiceProvider: ServiceProviderProtocol {
         searchService: SearchServiceProtocol = MockSearchService(),
         webViewConfigurationService: WebViewConfigurationServiceProtocol = MockWebViewConfigurationService(),
         bagService: BagServiceProtocol = MockBagService(),
-        wishlistService: WishlistServiceProtocol = MockWishlistService()
+        wishlistService: WishlistServiceProtocol = MockWishlistService(),
+        sessionService: SessionServiceProtocol = MockSessionService()
     ) {
         self.analytics = analytics
         self.authenticationService = authenticationService
@@ -64,6 +66,7 @@ public final class MockServiceProvider: ServiceProviderProtocol {
         self.webViewConfigurationService = webViewConfigurationService
         self.bagService = bagService
         self.wishlistService = wishlistService
+        self.sessionService = sessionService
     }
 
     public var onResetServicesCalled: (() -> Void)?

--- a/Alfie/AlfieKit/Sources/Mocks/Core/Services/MockSessionService.swift
+++ b/Alfie/AlfieKit/Sources/Mocks/Core/Services/MockSessionService.swift
@@ -1,0 +1,28 @@
+import Combine
+import Foundation
+import Models
+
+public final class MockSessionService: SessionServiceProtocol {
+    // MARK: SessionServiceProtocol
+
+    public var isUserLoggedPublisher: AnyPublisher<Bool, Never> {
+        $isUserLogged.eraseToAnyPublisher()
+    }
+
+    public func loginUser() {
+        isUserLogged = true
+    }
+
+    public func logoutUser() {
+        isUserLogged = false
+    }
+
+    // MARK: Lifecycle
+
+    @Published
+    private var isUserLogged: Bool
+
+    public init() {
+        self.isUserLogged = false
+    }
+}

--- a/Alfie/AlfieKit/Sources/Mocks/Core/Services/MockSessionService.swift
+++ b/Alfie/AlfieKit/Sources/Mocks/Core/Services/MockSessionService.swift
@@ -3,21 +3,21 @@ import Foundation
 import Models
 
 public final class MockSessionService: SessionServiceProtocol {
-    public var isUserSignInPublisher: AnyPublisher<Bool, Never> {
-        $isUserSignIn.eraseToAnyPublisher()
+    public var isUserSignedInPublisher: AnyPublisher<Bool, Never> {
+        $isUserSignedIn.eraseToAnyPublisher()
     }
 
-    @Published private var isUserSignIn: Bool
+    @Published private var isUserSignedIn: Bool
 
     public init() {
-        self.isUserSignIn = false
+        self.isUserSignedIn = false
     }
 
-    public func loginUser() {
-        isUserSignIn = true
+    public func signInUser() {
+        isUserSignedIn = true
     }
 
-    public func logoutUser() {
-        isUserSignIn = false
+    public func signOutUser() {
+        isUserSignedIn = false
     }
 }

--- a/Alfie/AlfieKit/Sources/Mocks/Core/Services/MockSessionService.swift
+++ b/Alfie/AlfieKit/Sources/Mocks/Core/Services/MockSessionService.swift
@@ -3,21 +3,21 @@ import Foundation
 import Models
 
 public final class MockSessionService: SessionServiceProtocol {
-    public var isUserLoggedPublisher: AnyPublisher<Bool, Never> {
-        $isUserLogged.eraseToAnyPublisher()
+    public var isUserSignInPublisher: AnyPublisher<Bool, Never> {
+        $isUserSignIn.eraseToAnyPublisher()
     }
 
-    @Published private var isUserLogged: Bool
+    @Published private var isUserSignIn: Bool
 
     public init() {
-        self.isUserLogged = false
+        self.isUserSignIn = false
     }
 
     public func loginUser() {
-        isUserLogged = true
+        isUserSignIn = true
     }
 
     public func logoutUser() {
-        isUserLogged = false
+        isUserSignIn = false
     }
 }

--- a/Alfie/AlfieKit/Sources/Mocks/Core/Services/MockSessionService.swift
+++ b/Alfie/AlfieKit/Sources/Mocks/Core/Services/MockSessionService.swift
@@ -3,10 +3,14 @@ import Foundation
 import Models
 
 public final class MockSessionService: SessionServiceProtocol {
-    // MARK: SessionServiceProtocol
-
     public var isUserLoggedPublisher: AnyPublisher<Bool, Never> {
         $isUserLogged.eraseToAnyPublisher()
+    }
+
+    @Published private var isUserLogged: Bool
+
+    public init() {
+        self.isUserLogged = false
     }
 
     public func loginUser() {
@@ -15,14 +19,5 @@ public final class MockSessionService: SessionServiceProtocol {
 
     public func logoutUser() {
         isUserLogged = false
-    }
-
-    // MARK: Lifecycle
-
-    @Published
-    private var isUserLogged: Bool
-
-    public init() {
-        self.isUserLogged = false
     }
 }

--- a/Alfie/AlfieKit/Sources/Models/Features/HomeViewModelProtocol.swift
+++ b/Alfie/AlfieKit/Sources/Models/Features/HomeViewModelProtocol.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+public protocol HomeViewModelProtocol: ObservableObject {
+    var homeTitle: String { get }
+    var signInButtonText: String { get }
+    var username: String? { get }
+    var memberSince: Int? { get }
+
+    func didTapSignInButton()
+}

--- a/Alfie/AlfieKit/Sources/Models/Services/Analytics/AnalyticsState.swift
+++ b/Alfie/AlfieKit/Sources/Models/Services/Analytics/AnalyticsState.swift
@@ -1,19 +1,19 @@
 public enum AnalyticsState {
-    case isUserSignIn(Bool)
+    case isUserSignedIn(Bool)
 }
 
 public extension AnalyticsState {
     var eventName: String {
         switch self {
-        case .isUserSignIn:
-            return "user_sign_in"
+        case .isUserSignedIn:
+            return "user_signed_in"
         }
     }
 
     var eventValue: String {
         switch self {
-        case .isUserSignIn(let isSignIn):
-            return isSignIn.description
+        case .isUserSignedIn(let isSignedIn):
+            return isSignedIn.description
         }
     }
 }

--- a/Alfie/AlfieKit/Sources/Models/Services/Analytics/AnalyticsState.swift
+++ b/Alfie/AlfieKit/Sources/Models/Services/Analytics/AnalyticsState.swift
@@ -1,19 +1,19 @@
 public enum AnalyticsState {
-    case isUserLoggedIn(Bool)
+    case isUserSignIn(Bool)
 }
 
 public extension AnalyticsState {
     var eventName: String {
         switch self {
-        case .isUserLoggedIn:
-            return "user_logged_in"
+        case .isUserSignIn:
+            return "user_sign_in"
         }
     }
 
     var eventValue: String {
         switch self {
-        case .isUserLoggedIn(let isLoggedIn):
-            return isLoggedIn.description
+        case .isUserSignIn(let isSignIn):
+            return isSignIn.description
         }
     }
 }

--- a/Alfie/AlfieKit/Sources/Models/Services/ServiceProviderProtocol.swift
+++ b/Alfie/AlfieKit/Sources/Models/Services/ServiceProviderProtocol.swift
@@ -22,6 +22,7 @@ public protocol ServiceProviderProtocol: AnyObject {
     var searchService: SearchServiceProtocol { get }
     var bagService: BagServiceProtocol { get }
     var wishlistService: WishlistServiceProtocol { get }
+    var sessionService: SessionServiceProtocol { get }
 
     // Reset services before the app itself is reset, to allow them to cleanup gracefully if necessary
     func resetServices()

--- a/Alfie/AlfieKit/Sources/Models/Services/Session/SessionServiceProtocol.swift
+++ b/Alfie/AlfieKit/Sources/Models/Services/Session/SessionServiceProtocol.swift
@@ -2,8 +2,8 @@ import Combine
 import Foundation
 
 public protocol SessionServiceProtocol {
-    var isUserSignInPublisher: AnyPublisher<Bool, Never> { get }
+    var isUserSignedInPublisher: AnyPublisher<Bool, Never> { get }
 
-    func loginUser()
-    func logoutUser()
+    func signInUser()
+    func signOutUser()
 }

--- a/Alfie/AlfieKit/Sources/Models/Services/Session/SessionServiceProtocol.swift
+++ b/Alfie/AlfieKit/Sources/Models/Services/Session/SessionServiceProtocol.swift
@@ -2,7 +2,7 @@ import Combine
 import Foundation
 
 public protocol SessionServiceProtocol {
-    var isUserLoggedPublisher: AnyPublisher<Bool, Never> { get }
+    var isUserSignInPublisher: AnyPublisher<Bool, Never> { get }
 
     func loginUser()
     func logoutUser()

--- a/Alfie/AlfieKit/Sources/Models/Services/Session/SessionServiceProtocol.swift
+++ b/Alfie/AlfieKit/Sources/Models/Services/Session/SessionServiceProtocol.swift
@@ -1,0 +1,9 @@
+import Combine
+import Foundation
+
+public protocol SessionServiceProtocol {
+    var isUserLoggedPublisher: AnyPublisher<Bool, Never> { get }
+
+    func loginUser()
+    func logoutUser()
+}


### PR DESCRIPTION
### Ticket

https://mindera.atlassian.net/browse/ALFMOB-151

### Description

This update ensures that the Sign In / Sign Out button in the `Account` section consistently reflects the user's authentication state, staying in sync with the `Home` screen button.

Changes implemented:
- Added a `SessionService` that holds user authentication state and is responsible to Sign In / Sign Out user.
- Refactor `HomeView` to have a `HomeViewModel`.
- Updated `HomeView ` to send event of Sign In / Sign Out to the `HomeViewModel` that will update authentication state in `SessionService`.
- Updated `AccountView` to send event of Sign In / Sign Out option selected to the `AccountViewModel` that will update authentication state in `SessionService`.

### Evidences

https://github.com/user-attachments/assets/0a98dcad-0665-4270-ae96-5c4a09b7b2bb

