### PR TITLE
ALFMOB-161: Incorrect Wishlist Header when opened from bottom bar

### DIFF
--- a/Alfie/Alfie/Helpers/ToolbarItemProvider.swift
+++ b/Alfie/Alfie/Helpers/ToolbarItemProvider.swift
@@ -120,11 +120,13 @@ enum ToolbarItemProvider {
                     accountItem(with: coordinator, size: .big)
 
                 case .shop,
-                    .wishlist,
                     .bag:
                     if isWishlistEnabled {
                         wishlistItem(with: coordinator, size: .big)
                     }
+                    accountItem(with: coordinator, size: .big)
+
+                case .wishlist:
                     accountItem(with: coordinator, size: .big)
                 }
 

--- a/Alfie/Alfie/Navigation/ViewFactory.swift
+++ b/Alfie/Alfie/Navigation/ViewFactory.swift
@@ -44,6 +44,7 @@ final class ViewFactory: ViewFactoryProtocol {
 
             case .wishlist:
                 wishlistView
+                    .withToolbar(for: .tab(.wishlist))
 
             case .bag:
                 BagView(
@@ -123,6 +124,7 @@ final class ViewFactory: ViewFactoryProtocol {
 
         case .wishlist:
             wishlistView
+                .withToolbar(for: .wishlist)
 
         case .productDetails(let type):
             switch type {

--- a/Alfie/Alfie/Views/WishlistView/WishlistView.swift
+++ b/Alfie/Alfie/Views/WishlistView/WishlistView.swift
@@ -32,7 +32,6 @@ struct WishlistView<ViewModel: WishlistViewModelProtocol>: View {
             .padding(.horizontal, Spacing.space200)
         }
         .padding(.vertical, Spacing.space200)
-        .withToolbar(for: .wishlist)
         .onAppear {
             viewModel.viewDidAppear()
         }


### PR DESCRIPTION
### Ticket

https://mindera.atlassian.net/browse/ALFMOB-161

### Description

The **Wishlist toolbar** was being defined in `WishlistView`, causing it to always use the same header. regardless of how the view was opened.

**How it was fixed:**
- Moved toolbar definition to `ViewFactory`, ensuring the correct header is applied based on whether the view is opened from the **bottom bar** or via a **push event**.

### Evidences
<img src="https://github.com/user-attachments/assets/96c98814-9bd5-485f-91d7-53e57a506936" width="300">
<img src="https://github.com/user-attachments/assets/5017a38f-6415-4abc-b3f7-3f8b414956b2" width="300">
