### PR TITLE
fix: Configure GPG agent for loopback pinentry in CI

### DIFF
--- a/.github/workflows/alfie.yml
+++ b/.github/workflows/alfie.yml
@@ -7,7 +7,9 @@ on:
 
   pull_request:
     branches:
-      - 'main'
+      - "main"
+
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -97,7 +99,7 @@ jobs:
           SECRETS_GPG_PASSPHRASE: ${{ secrets.SECRETS_GPG_PASSPHRASE }}
         run: |
           echo "$SECRETS_GPG_PRIVATE_KEY" | gpg --batch --yes --import
-          git secret reveal -p "$SECRETS_GPG_PASSPHRASE"
+          git secret reveal -p "$SECRETS_GPG_PASSPHRASE" -v
 
       - name: Run Tests
         run: bundle exec fastlane ios test --env default

--- a/.github/workflows/alfie.yml
+++ b/.github/workflows/alfie.yml
@@ -98,8 +98,17 @@ jobs:
           SECRETS_GPG_PRIVATE_KEY: ${{ secrets.SECRETS_GPG_PRIVATE_KEY }}
           SECRETS_GPG_PASSPHRASE: ${{ secrets.SECRETS_GPG_PASSPHRASE }}
         run: |
+          git config --global user.email "${{ secrets.GIT_EMAIL }}"
+          git config --global user.name "${{ secrets.GIT_USER_NAME }}"
+          mkdir -p ~/.gnupg
+          chmod 700 ~/.gnupg
+          echo "allow-loopback-pinentry" > ~/.gnupg/gpg-agent.conf
+          echo "pinentry-mode loopback" > ~/.gnupg/gpg.conf
+          chmod 600 ~/.gnupg/gpg-agent.conf
+          chmod 600 ~/.gnupg/gpg.conf
           echo "$SECRETS_GPG_PRIVATE_KEY" | gpg --batch --yes --import
-          git secret reveal -p "$SECRETS_GPG_PASSPHRASE" -v
+          gpg-connect-agent reloadagent /bye || true
+          git secret reveal -p "$SECRETS_GPG_PASSPHRASE"
 
       - name: Run Tests
         run: bundle exec fastlane ios test --env default
@@ -161,7 +170,16 @@ jobs:
           SECRETS_GPG_PRIVATE_KEY: ${{ secrets.SECRETS_GPG_PRIVATE_KEY }}
           SECRETS_GPG_PASSPHRASE: ${{ secrets.SECRETS_GPG_PASSPHRASE }}
         run: |
+          git config --global user.email "${{ secrets.GIT_EMAIL }}"
+          git config --global user.name "${{ secrets.GIT_USER_NAME }}"
+          mkdir -p ~/.gnupg
+          chmod 700 ~/.gnupg
+          echo "allow-loopback-pinentry" > ~/.gnupg/gpg-agent.conf
+          echo "pinentry-mode loopback" > ~/.gnupg/gpg.conf
+          chmod 600 ~/.gnupg/gpg-agent.conf
+          chmod 600 ~/.gnupg/gpg.conf
           echo "$SECRETS_GPG_PRIVATE_KEY" | gpg --batch --yes --import
+          gpg-connect-agent reloadagent /bye || true
           git secret reveal -p "$SECRETS_GPG_PASSPHRASE"
 
       - name: Build and deploy release to TestFlight


### PR DESCRIPTION
## Description
Enable loopback pinentry mode for GPG agent to allow non-interactive passphrase input in CI environment. Newer GPG versions require this configuration to accept passphrases via stdin instead of attempting interactive prompts that fail in GitHub Actions runners.

Also add workflow_dispatch trigger to allow manual workflow runs.

## Fixes

https://github.com/Mindera/Alfie-iOS/actions/runs/21993786204/job/63762912519
https://github.com/Mindera/Alfie-iOS/actions/runs/22077582529/job/63796066579

## Sub Tickets
The `alfie.yml` GH action configuration should be improved with https://mindera.atlassian.net/browse/ALFMOB-236