### PR TITLE
Harmonise AI agent skills with cross-platform standard

### DIFF
--- a/.ai/agents/feature-developer.agent.md
+++ b/.ai/agents/feature-developer.agent.md
@@ -1,6 +1,6 @@
 ---
-name: ios-feature-developer
-description: Specialized agent for implementing iOS features following MVVM architecture and project conventions
+name: feature-developer
+description: Implements iOS features following MVVM architecture with flow-based navigation
 tools: ['execute', 'read', 'edit', 'search', 'web', 'agent', 'todo']
 ---
 
@@ -72,4 +72,4 @@ public class FeatureViewModel: FeatureViewModelProtocol {
 - **testing-specialist**: Test coverage
 - **localization-specialist**: Strings
 - **spec-writer**: Spec updates
-- **mobile-security-specialist**: Security review
+- **security-specialist**: Security review

--- a/.ai/agents/feature-orchestrator.agent.md
+++ b/.ai/agents/feature-orchestrator.agent.md
@@ -91,7 +91,7 @@ Spec: Docs/Specs/Features/<Feature>.md (Testing Strategy section)
 ### Phase 7: Security Audit
 ```
 @security-specialist Audit [Feature Name].
-Files: AlfieKit/Sources/<Feature>/, Core/Services/<Feature>/
+Files: Alfie/AlfieKit/Sources/<Feature>/, Alfie/AlfieKit/Sources/Core/Services/<Feature>/
 ```
 
 ## Quality Gates

--- a/.ai/agents/feature-orchestrator.agent.md
+++ b/.ai/agents/feature-orchestrator.agent.md
@@ -23,12 +23,12 @@ You are the Feature Orchestrator for the Alfie iOS application. You coordinate s
 | Phase | Agent | Output |
 |-------|-------|--------|
 | 1. Specification | `spec-writer` | `Docs/Specs/Features/<Feature>.md` |
-| 2. Security Review | `mobile-security-specialist` | Security requirements |
+| 2. Security Review | `security-specialist` | Security requirements |
 | 3. GraphQL Layer | `graphql-specialist` | Queries, fragments, converters |
 | 4. Localization | `localization-specialist` | L10n.xcstrings entries |
-| 5. Implementation | `ios-feature-developer` | MVVM feature code |
+| 5. Implementation | `feature-developer` | MVVM feature code |
 | 6. Testing | `testing-specialist` | Unit tests, snapshots |
-| 7. Security Audit | `mobile-security-specialist` | Security checklist |
+| 7. Security Audit | `security-specialist` | Security checklist |
 | 8. Final Verification | (orchestrator) | Build & test pass |
 
 ## Phase Dependencies
@@ -77,7 +77,7 @@ Keys needed: [list from spec]
 
 ### Phase 5: Implementation
 ```
-@ios-feature-developer Implement [Feature Name].
+@feature-developer Implement [Feature Name].
 Spec: Docs/Specs/Features/<Feature>.md
 Prerequisites complete: ✅ GraphQL, ✅ L10n
 ```
@@ -90,7 +90,7 @@ Spec: Docs/Specs/Features/<Feature>.md (Testing Strategy section)
 
 ### Phase 7: Security Audit
 ```
-@mobile-security-specialist Audit [Feature Name].
+@security-specialist Audit [Feature Name].
 Files: AlfieKit/Sources/<Feature>/, Core/Services/<Feature>/
 ```
 
@@ -137,12 +137,12 @@ Legend: ✅ Complete | 🔄 In Progress | ⬜ Not Started
 
 ### Test Failure
 1. Identify failing tests
-2. Delegate fix to `testing-specialist` or `ios-feature-developer`
+2. Delegate fix to `testing-specialist` or `feature-developer`
 3. Re-run tests
 
 ### Security Issues
 1. Document findings
-2. Delegate fixes to `ios-feature-developer`
+2. Delegate fixes to `feature-developer`
 3. Re-audit until resolved
 
 ## Final Verification

--- a/.ai/agents/graphql-specialist.agent.md
+++ b/.ai/agents/graphql-specialist.agent.md
@@ -29,6 +29,36 @@ You are a GraphQL specialist for the Alfie iOS application. You handle queries, 
 | Handle optional fields gracefully | Over-fetch data |
 | Test converters | Skip build verification |
 
+## Example Pattern
+
+**Query** (`Queries/Product/Queries.graphql`):
+```graphql
+query GetProduct($productId: String!) {
+    product(productId: $productId) {
+        ...ProductFragment
+    }
+}
+```
+
+**Fragment** (`Queries/Product/Fragments/ProductFragment.graphql`):
+```graphql
+fragment ProductFragment on Product {
+    id
+    name
+    brand { ...BrandFragment }
+    price { ...PriceFragment }
+}
+```
+
+**Converter** (`Core/Services/BFFService/Converters/ProductConverter.swift`):
+```swift
+extension ProductFragment {
+    func toProduct() -> Product? {
+        Product(id: id, name: name, brand: brand?.toBrand(), price: price.toPrice())
+    }
+}
+```
+
 ## Collaboration
 
-Work with **ios-feature-developer** (implementation), **testing-specialist** (converter tests)
+Work with **feature-developer** (implementation), **testing-specialist** (converter tests)

--- a/.ai/agents/graphql-specialist.agent.md
+++ b/.ai/agents/graphql-specialist.agent.md
@@ -31,30 +31,30 @@ You are a GraphQL specialist for the Alfie iOS application. You handle queries, 
 
 ## Example Pattern
 
-**Query** (`Queries/Product/Queries.graphql`):
+**Query** (`AlfieKit/Sources/BFFGraph/CodeGen/Queries/Products/Queries.graphql`):
 ```graphql
-query GetProduct($productId: String!) {
-    product(productId: $productId) {
+query GetProduct($productId: ID!) {
+    product(id: $productId) {
         ...ProductFragment
     }
 }
 ```
 
-**Fragment** (`Queries/Product/Fragments/ProductFragment.graphql`):
+**Fragment** (`AlfieKit/Sources/BFFGraph/CodeGen/Queries/Products/Details/Fragments/ProductFragment.graphql`):
 ```graphql
 fragment ProductFragment on Product {
     id
     name
     brand { ...BrandFragment }
-    price { ...PriceFragment }
+    priceRange { ...PriceRangeFragment }
 }
 ```
 
-**Converter** (`Core/Services/BFFService/Converters/ProductConverter.swift`):
+**Converter** (`Core/Services/BFFService/Converters/ProductFragment+Converter.swift`):
 ```swift
-extension ProductFragment {
-    func toProduct() -> Product? {
-        Product(id: id, name: name, brand: brand?.toBrand(), price: price.toPrice())
+extension BFFGraphAPI.ProductFragment {
+    func convertToProduct() -> Product {
+        Product(id: id, name: name, brand: brand.fragments.brandFragment.convertToBrand())
     }
 }
 ```

--- a/.ai/agents/graphql-specialist.agent.md
+++ b/.ai/agents/graphql-specialist.agent.md
@@ -12,11 +12,11 @@ You are a GraphQL specialist for the Alfie iOS application. You handle queries, 
 
 ## Workflow
 
-1. Create query in `AlfieKit/Sources/BFFGraph/CodeGen/Queries/<Feature>/Queries.graphql`
-2. Create fragments in `Queries/<Feature>/Fragments/<Model>Fragment.graphql`
-3. Extend schema in `CodeGen/Schema/schema-<feature>.graphqls` (if needed)
+1. Create query in `Alfie/AlfieKit/Sources/BFFGraph/CodeGen/Queries/<Feature>/Queries.graphql`
+2. Create fragments in `Alfie/AlfieKit/Sources/BFFGraph/CodeGen/Queries/<Feature>/<SubFeature>/Fragments/<Model>Fragment.graphql`
+3. Extend schema in `Alfie/AlfieKit/Sources/BFFGraph/CodeGen/Schema/schema-<feature>.graphqls` (if needed)
 4. Run codegen: `cd Alfie/scripts && ./run-apollo-codegen.sh`
-5. Create converters in `Core/Services/BFFService/Converters/`
+5. Create converters in `Alfie/AlfieKit/Sources/Core/Services/BFFService/Converters/`
 6. Add fetch method in `BFFClientService.swift`
 7. **Verify**: `./Alfie/scripts/verify.sh` (build + tests)
 
@@ -31,7 +31,7 @@ You are a GraphQL specialist for the Alfie iOS application. You handle queries, 
 
 ## Example Pattern
 
-**Query** (`AlfieKit/Sources/BFFGraph/CodeGen/Queries/Products/Queries.graphql`):
+**Query** (`Alfie/AlfieKit/Sources/BFFGraph/CodeGen/Queries/Products/Queries.graphql`):
 ```graphql
 query GetProduct($productId: ID!) {
     product(id: $productId) {
@@ -40,7 +40,7 @@ query GetProduct($productId: ID!) {
 }
 ```
 
-**Fragment** (`AlfieKit/Sources/BFFGraph/CodeGen/Queries/Products/Details/Fragments/ProductFragment.graphql`):
+**Fragment** (`Alfie/AlfieKit/Sources/BFFGraph/CodeGen/Queries/Products/Details/Fragments/ProductFragment.graphql`):
 ```graphql
 fragment ProductFragment on Product {
     id
@@ -50,11 +50,22 @@ fragment ProductFragment on Product {
 }
 ```
 
-**Converter** (`Core/Services/BFFService/Converters/ProductFragment+Converter.swift`):
+**Converter** (`Alfie/AlfieKit/Sources/Core/Services/BFFService/Converters/ProductFragment+Converter.swift`):
 ```swift
+// Simplified — see actual file for all required fields
 extension BFFGraphAPI.ProductFragment {
     func convertToProduct() -> Product {
-        Product(id: id, name: name, brand: brand.fragments.brandFragment.convertToBrand())
+        Product(
+            id: id,
+            styleNumber: styleNumber,
+            name: name,
+            brand: brand.fragments.brandFragment.convertToBrand(),
+            shortDescription: shortDescription,
+            longDescription: longDescription,
+            slug: slug,
+            defaultVariant: defaultVariant.fragments.variantFragment.convertToVariant(colours: []),
+            variants: variants.map { $0.fragments.variantFragment.convertToVariant(colours: []) }
+        )
     }
 }
 ```

--- a/.ai/agents/localization-specialist.agent.md
+++ b/.ai/agents/localization-specialist.agent.md
@@ -44,3 +44,7 @@ Usage: `Text(L10n.Plp.NumberOfResults.message(count))`
 ## Testing
 
 Add tests in `SharedUITests/LocalizationTests.swift` to verify keys exist and pluralization works.
+
+## Collaboration
+
+Work with **feature-developer** (string integration), **spec-writer** (L10n key definitions)

--- a/.ai/agents/security-specialist.agent.md
+++ b/.ai/agents/security-specialist.agent.md
@@ -1,5 +1,5 @@
 ---
-name: mobile-security-specialist
+name: security-specialist
 description: Expert in iOS mobile security, identifying vulnerabilities, and ensuring secure coding practices
 tools: ['execute', 'read', 'search', 'web', 'agent', 'todo']
 ---
@@ -55,4 +55,4 @@ You are a mobile security specialist identifying and preventing security vulnera
 
 ## Collaboration
 
-Work with **ios-feature-developer** on secure implementation fixes.
+Work with **feature-developer** on secure implementation fixes.

--- a/.ai/agents/spec-writer.agent.md
+++ b/.ai/agents/spec-writer.agent.md
@@ -36,3 +36,15 @@ You are a spec writer creating detailed feature specifications for the Alfie iOS
 | Include Swift code for models | Forget localization keys |
 | Specify all L10n keys | Skip edge case documentation |
 | Document all edge cases | Omit testing strategy |
+
+## Acceptance Criteria Example
+
+Good:
+> **Given** a user is on the PLP with active filters, **When** they tap "Clear All", **Then** all filters are removed, the product list refreshes, and the filter count badge disappears.
+
+Bad:
+> Filters should work correctly and be clearable.
+
+## Collaboration
+
+Work with **feature-orchestrator** (assigns work), **feature-developer** (consumes specs)

--- a/.ai/agents/testing-specialist.agent.md
+++ b/.ai/agents/testing-specialist.agent.md
@@ -57,4 +57,4 @@ You are a testing specialist ensuring comprehensive test coverage for the Alfie 
 
 ## Collaboration
 
-Work with **ios-feature-developer** (ViewModels), **graphql-specialist** (converters)
+Work with **feature-developer** (ViewModels), **graphql-specialist** (converters)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,1 @@
-# Alfie iOS - Project Instructions
-
-**See `AGENTS.md` in the project root for complete project documentation.**
-
-This file exists for compatibility with GitHub Copilot's `.github/copilot-instructions.md` convention.
+../agents.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,10 +15,10 @@ Alfie uses specialized AI agents for different development tasks. All agents are
 | `feature-orchestrator` | Coordinate full feature development lifecycle | `.ai/agents/feature-orchestrator.agent.md` |
 | `spec-writer` | Create comprehensive feature specifications | `.ai/agents/spec-writer.agent.md` |
 | `graphql-specialist` | GraphQL queries, mutations, and Apollo codegen | `.ai/agents/graphql-specialist.agent.md` |
-| `ios-feature-developer` | MVVM iOS feature implementation | `.ai/agents/ios-feature-developer.agent.md` |
+| `feature-developer` | MVVM iOS feature implementation | `.ai/agents/feature-developer.agent.md` |
 | `localization-specialist` | L10n string catalog management | `.ai/agents/localization-specialist.agent.md` |
 | `testing-specialist` | Unit tests, snapshot tests, and test coverage | `.ai/agents/testing-specialist.agent.md` |
-| `mobile-security-specialist` | Security audits and vulnerability identification | `.ai/agents/mobile-security-specialist.agent.md` |
+| `security-specialist` | Security audits and vulnerability identification | `.ai/agents/security-specialist.agent.md` |
 
 ### Usage
 
@@ -26,7 +26,7 @@ AI tools should read the agent definition from `.ai/agents/<agent-name>.agent.md
 
 **Example:**
 ```
-Acting as the ios-feature-developer agent (see .ai/agents/ios-feature-developer.agent.md),
+Acting as the feature-developer agent (see .ai/agents/feature-developer.agent.md),
 implement the Product Details feature following the spec in Docs/Specs/Features/ProductDetails.md
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,1 @@
-# Alfie iOS - Claude Code Instructions
-
-**Consult @AGENTS.md for complete project guidelines.**
-
-This file provides guidance to Claude Code (claude.ai/code) when working with this repository.
+agents.md


### PR DESCRIPTION
## Summary

Standardises AI agent names and structure to be consistent across iOS, Android, and Flutter.

## Changes

- **Renamed** `ios-feature-developer` → `feature-developer`
- **Renamed** `mobile-security-specialist` → `security-specialist`
- Updated all cross-references in orchestrator and other agents to use new names
- Enhanced `graphql-specialist` with example query/fragment/converter pattern
- Enhanced `spec-writer` with acceptance criteria example and collaboration section
- Added collaboration section to `localization-specialist`
- Updated `AGENTS.md` agent table to reflect new standardised names

## Agent names (now identical across all 3 platforms)

`feature-orchestrator`, `feature-developer`, `graphql-specialist`, `localization-specialist`, `security-specialist`, `spec-writer`, `testing-specialist`

All agents in `.ai/agents/` for tool-agnostic compatibility (GitHub Copilot, Claude, Cursor, etc.)