### PR TITLE
ALFMOB-362: speed up iOS CI/CD workflow

### DIFF
--- a/.github/workflows/alfie.yml
+++ b/.github/workflows/alfie.yml
@@ -55,7 +55,7 @@ jobs:
           path: |
             ~/Library/Caches/org.swift.swiftpm
             ${{ env.SPM_CLONED_DEPENDENCIES_PATH }}
-          key: spm-${{ runner.os }}-${{ hashFiles('Alfie/AlfieKit/Package.swift', 'Alfie/AlfieKit/Package.resolved') }}
+          key: spm-${{ runner.os }}-${{ hashFiles('Alfie/AlfieKit/Package.swift', 'Alfie/AlfieKit/Package.resolved', 'Alfie/Alfie.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
           restore-keys: |
             spm-${{ runner.os }}-
 
@@ -63,7 +63,7 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: build/DerivedData
-          key: derived-${{ runner.os }}-${{ hashFiles('Alfie/AlfieKit/Package.resolved') }}
+          key: derived-${{ runner.os }}-${{ hashFiles('Alfie/AlfieKit/Package.resolved', 'Alfie/Alfie.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
           restore-keys: |
             derived-${{ runner.os }}-
 
@@ -141,7 +141,7 @@ jobs:
           path: |
             ~/Library/Caches/org.swift.swiftpm
             ${{ env.SPM_CLONED_DEPENDENCIES_PATH }}
-          key: spm-${{ runner.os }}-${{ hashFiles('Alfie/AlfieKit/Package.swift', 'Alfie/AlfieKit/Package.resolved') }}
+          key: spm-${{ runner.os }}-${{ hashFiles('Alfie/AlfieKit/Package.swift', 'Alfie/AlfieKit/Package.resolved', 'Alfie/Alfie.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
           restore-keys: |
             spm-${{ runner.os }}-
 

--- a/.github/workflows/alfie.yml
+++ b/.github/workflows/alfie.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches:
       - "main"
+    paths-ignore:
+      - "**/*.md"
+      - "Docs/**"
 
   workflow_dispatch:
 
@@ -20,15 +23,15 @@ env:
   SPM_CLONED_DEPENDENCIES_PATH: "/tmp/SourcePackages"
 
 jobs:
-  setup:
+  unit-tests:
     runs-on: macos-26
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - name: Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Cache Homebrew
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/Library/Caches/Homebrew
@@ -37,36 +40,8 @@ jobs:
           restore-keys: |
             brew-${{ runner.os }}-
 
-      - name: Cache Ruby Gems
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        with:
-          path: vendor/bundle
-          key: gems-${{ runner.os }}-${{ hashFiles('Gemfile', 'Gemfile.lock') }}
-          restore-keys: |
-            gems-${{ runner.os }}-${{ hashFiles('Gemfile') }}-
-            gems-${{ runner.os }}-
-
-      - name: Install Homebrew formulas
-        run: |
-          brew update
-          brew bundle install
-
-      - name: Install Ruby dependencies
-        run: |
-          gem install bundler --no-document
-          bundle config set --local path 'vendor/bundle'
-          bundle install --jobs 4 --retry 3
-
-  unit-tests:
-    needs: setup
-    runs-on: macos-26
-    timeout-minutes: 30
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-
       - name: Restore Ruby Gems
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: vendor/bundle
           key: gems-${{ runner.os }}-${{ hashFiles('Gemfile', 'Gemfile.lock') }}
@@ -75,7 +50,7 @@ jobs:
             gems-${{ runner.os }}-
 
       - name: Restore Swift Package Manager Cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/Library/Caches/org.swift.swiftpm
@@ -84,9 +59,16 @@ jobs:
           restore-keys: |
             spm-${{ runner.os }}-
 
+      - name: Cache Xcode DerivedData
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: build/DerivedData
+          key: derived-${{ runner.os }}-${{ hashFiles('Alfie/AlfieKit/Package.resolved') }}
+          restore-keys: |
+            derived-${{ runner.os }}-
+
       - name: Install Homebrew formulas
-        run: |
-          brew bundle install
+        run: brew bundle install
 
       - name: Install Ruby dependencies
         run: |
@@ -116,8 +98,8 @@ jobs:
           BUILD_CONFIGURATION: "Debug"
 
       - name: Upload Test Results
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: failure()
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: test-results
           path: |
@@ -126,16 +108,26 @@ jobs:
           retention-days: 7
 
   release:
-    needs: [setup, unit-tests]
+    needs: [unit-tests]
     runs-on: macos-26
     timeout-minutes: 60
     if: github.event_name == 'push'
     steps:
       - name: Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Cache Homebrew
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/Library/Caches/Homebrew
+            /usr/local/Homebrew
+          key: brew-${{ runner.os }}-${{ hashFiles('Brewfile') }}
+          restore-keys: |
+            brew-${{ runner.os }}-
 
       - name: Restore Ruby Gems
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: vendor/bundle
           key: gems-${{ runner.os }}-${{ hashFiles('Gemfile', 'Gemfile.lock') }}
@@ -144,7 +136,7 @@ jobs:
             gems-${{ runner.os }}-
 
       - name: Restore Swift Package Manager Cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/Library/Caches/org.swift.swiftpm
@@ -154,8 +146,7 @@ jobs:
             spm-${{ runner.os }}-
 
       - name: Install Homebrew formulas
-        run: |
-          brew bundle install
+        run: brew bundle install
 
       - name: Configure Bundler
         run: |

--- a/Alfie/Alfie/AlfieApp.swift
+++ b/Alfie/Alfie/AlfieApp.swift
@@ -71,3 +71,4 @@ struct AlfieApp: App {
         appDelegate.serviceProvider.deepLinkService.openUrls([url])
     }
 }
+

--- a/fastlane/.env.default
+++ b/fastlane/.env.default
@@ -40,6 +40,7 @@ SCAN_TESTPLAN=${TESTPLAN}
 SCAN_OUTPUT_DIRECTORY=${ARTIFACTS_PATH}
 SCAN_XCARGS=${EXTRA_XCARGS}
 SCAN_RESULT_BUNDLE=true
+SCAN_DERIVED_DATA_PATH="${ROOT_PATH}/build/DerivedData"
 
 #######################################################################
 # match (https://github.com/fastlane/fastlane/blob/master/match/lib/match/options.rb)


### PR DESCRIPTION
## Summary

Cuts PR wall time on `Alfie CI/CD` by caching compiled Swift artefacts in `unit-tests` and trimming wasted setup/orchestration across the workflow. Target: PR runs under ~6 min on a warm cache (baseline ~10 min).

Jira: [ALFMOB-362](https://mindera.atlassian.net/browse/ALFMOB-362)

## Changes

- **Delete `setup` job.** macOS runners are ephemeral; downstream jobs already install brew/bundler themselves, so the job was ~1 min of orchestration for no net benefit.
- **Cache Xcode DerivedData** in `unit-tests` at a repo-local path (`build/DerivedData`), keyed on `Package.resolved` with a broad `restore-keys` fallback. This is the main win — AlfieKit + the full Firebase SDK graph no longer recompile from scratch every PR.
- **Pin scan derived-data path** via `SCAN_DERIVED_DATA_PATH` in `fastlane/.env.default` so the cache directory is predictable and tightly scoped.
- **Bump GitHub Actions to v5** (`actions/checkout`, `actions/cache`, `actions/upload-artifact`), SHA-pinned. Clears the June 2026 Node 24 deprecation warnings.
- **Drop `brew update`**. Brewfile is two formulas (`git-secret`, `xcbeautify`); the pre-installed Homebrew on `macos-26` is recent enough.
- **Test-results artefact on failure only.** Stops uploading xcresult bundles on green runs.
- **Skip workflow on doc-only PRs** via `paths-ignore` for `**/*.md` and `Docs/**`. `push:` to `main` is intentionally unfiltered.

## Out of scope

- `GYM_CLEAN=true` is retained on the `release` job for build safety. `gym` wipes the build dir on every invocation, so `release` cannot benefit from a compiled-output cache; its savings here come only from the removed `setup` job and `brew update`. The original ticket bullet "release no longer recompiles the full SPM graph when Package.resolved is unchanged" will not be met as-is — flagging for the reporter to renegotiate or split.
- Parallel testing in `scan` (`parallel-testing-enabled`) — left for a follow-up once parallel-safety is confirmed across the test suite.

## Test plan

- [x] First run (cold cache) completes successfully — establish baseline.
- [x] Second push (e.g. trivial whitespace) shows `Run Tests` materially faster than the cold run and faster than the ~9m11s reference baseline.
- [x] PR wall time on the warm-cache run is under ~6 min.
- [x] `unit-tests` logs show a cache hit on `Cache Xcode DerivedData`.
- [x] No deprecated-action annotations in the run.
- [x] Push a docs-only commit (e.g. README tweak) on a PR branch and confirm the workflow does not trigger.
- [x] Green run produces no `test-results` artefact; failing run still uploads xcresult + junit.
- [ ] Merge to `main` and confirm `release` still builds and deploys to TestFlight as before (no regression — this PR doesn't change release behaviour materially).

🤖 Generated with [Claude Code](https://claude.com/claude-code)