### PR TITLE
ALFMOB-386: Resolve PDP deep links by product slug

### DIFF
--- a/Alfie/AlfieKit/Sources/AppFeature/Navigation/AppFeatureViewModel.swift
+++ b/Alfie/AlfieKit/Sources/AppFeature/Navigation/AppFeatureViewModel.swift
@@ -225,9 +225,9 @@ public final class AppFeatureViewModel: AppFeatureViewModelProtocol {
                 )
             )
 
-        case .productDetail(let productId, _, _, _):
-            // TODO: currently the API does not support fetching a product by the StyleNumber (that is parsed from the URL), just by ProductID, so all requests will return "not found"
-            rootTabViewModel.navigate(.shop(.productDetails(.productDetails(.id(productId)))))
+        case .productDetail(let slug, _, _):
+            // The BFF resolves a product by its slug, which is exactly the `/product/<slug>` path segment.
+            rootTabViewModel.navigate(.shop(.productDetails(.productDetails(.deepLink(handle: slug)))))
 
         case .webView(let url):
             rootTabViewModel.navigate(.shop(.web(url: url, title: "")))

--- a/Alfie/AlfieKit/Sources/CategorySelector/Navigation/CategorySelectorFlowViewModel.swift
+++ b/Alfie/AlfieKit/Sources/CategorySelector/Navigation/CategorySelectorFlowViewModel.swift
@@ -205,7 +205,7 @@ public final class CategorySelectorFlowViewModel: CategorySelectorFlowViewModelP
                     switch productDetailsRoute {
                     case .productDetails(let configuration):
                         switch configuration {
-                        case .id(let configurationProductID):
+                        case .id(let configurationProductID), .deepLink(let configurationProductID):
                             productID = configurationProductID
                             product = nil
 

--- a/Alfie/AlfieKit/Sources/DeepLink/Extensions/DeepLinkService+Extension.swift
+++ b/Alfie/AlfieKit/Sources/DeepLink/Extensions/DeepLinkService+Extension.swift
@@ -8,7 +8,7 @@ public extension DeepLinkService {
         let parsers: [DeepLinkParserProtocol] = [
             InternalDeepLinkParser(configuration: configuration),
             ProductListingDeepLinkParser(configuration: configuration),
-            ProductDetailsDeepLinkParser(configuration: configuration, log: log),
+            ProductDetailsDeepLinkParser(configuration: configuration),
             DefaultDeepLinkParser(configuration: configuration),
         ] // Order is important!
         self.init(parsers: parsers, configuration: configuration, log: log)

--- a/Alfie/AlfieKit/Sources/DeepLink/Extensions/DeepLinkService+Extension.swift
+++ b/Alfie/AlfieKit/Sources/DeepLink/Extensions/DeepLinkService+Extension.swift
@@ -8,7 +8,7 @@ public extension DeepLinkService {
         let parsers: [DeepLinkParserProtocol] = [
             InternalDeepLinkParser(configuration: configuration),
             ProductListingDeepLinkParser(configuration: configuration),
-            ProductDetailsDeepLinkParser(configuration: configuration),
+            ProductDetailsDeepLinkParser(configuration: configuration, log: log),
             DefaultDeepLinkParser(configuration: configuration),
         ] // Order is important!
         self.init(parsers: parsers, configuration: configuration, log: log)

--- a/Alfie/AlfieKit/Sources/DeepLink/Parsers/ProductDetailsDeepLinkParser.swift
+++ b/Alfie/AlfieKit/Sources/DeepLink/Parsers/ProductDetailsDeepLinkParser.swift
@@ -1,3 +1,4 @@
+import AlicerceLogging
 import Foundation
 import Model
 import RegexBuilder
@@ -5,34 +6,22 @@ import Utils
 
 final class ProductDetailsDeepLinkParser: DeepLinkParserProtocol {
     let configuration: LinkConfigurationProtocol
+    private let log: Logger
 
     private enum Constants {
         static let urlPrefixRegex = /\/product\//.ignoresCase()
-        static let productDescriptionRegex = ZeroOrMore(.any)
-        static let productIdLength = 8
         static let routePrefixRegex = "nav="
         static let routeRegex = ZeroOrMore(.digit)
     }
 
     // MARK: Regex Components
 
+    /// Captures the whole `/product/<slug>` path segment as the BFF handle. The slug is used as-is — the
+    /// BFF resolves a product by its slug, so there is nothing else to extract.
     private let urlRegex = Regex {
         Constants.urlPrefixRegex
-        productRegex
-    }
-
-    private static let productRegex = Regex {
-        /// product description
         Capture {
-            Constants.productDescriptionRegex
-        } transform: {
-            String($0)
-        }
-        /// product id
-        TryCapture {
-            Repeat(Constants.productIdLength...Constants.productIdLength) {
-                .digit
-            }
+            OneOrMore(.any)
         } transform: {
             String($0)
         }
@@ -48,26 +37,28 @@ final class ProductDetailsDeepLinkParser: DeepLinkParserProtocol {
         }
     }
 
-    init(configuration: LinkConfigurationProtocol) {
+    init(configuration: LinkConfigurationProtocol, log: Logger) {
         self.configuration = configuration
+        self.log = log
     }
 
     func parseUrl(_ url: URL) -> DeepLink? {
         guard configuration.isURLSupported(url) else {
+            log.debug("[PDP deeplink] '\(url.absoluteString)' rejected: scheme/host not supported")
             return nil
         }
 
         guard let productMatch = url.path().wholeMatch(of: urlRegex) else {
+            log.debug("[PDP deeplink] path '\(url.path())' is not a /product/<slug> link (falls through to webView)")
             return nil
         }
-        let productDescription = productMatch.output.1
-        let productId = productMatch.output.2
+        let slug = productMatch.output.1
         let navigationRoute = url.query().flatMap { extractRoute(from: $0) }
         let normalisedWebUrl = url.httpSecureUrl(using: configuration)
+        log.debug("[PDP deeplink] matched: slug='\(slug)'")
         return .init(
             type: .productDetail(
-                id: productId,
-                description: productDescription,
+                slug: slug,
                 route: navigationRoute,
                 query: url.queryParameters
             ),

--- a/Alfie/AlfieKit/Sources/DeepLink/Parsers/ProductDetailsDeepLinkParser.swift
+++ b/Alfie/AlfieKit/Sources/DeepLink/Parsers/ProductDetailsDeepLinkParser.swift
@@ -1,4 +1,3 @@
-import AlicerceLogging
 import Foundation
 import Model
 import RegexBuilder
@@ -6,7 +5,6 @@ import Utils
 
 final class ProductDetailsDeepLinkParser: DeepLinkParserProtocol {
     let configuration: LinkConfigurationProtocol
-    private let log: Logger
 
     private enum Constants {
         static let urlPrefixRegex = /\/product\//.ignoresCase()
@@ -37,25 +35,21 @@ final class ProductDetailsDeepLinkParser: DeepLinkParserProtocol {
         }
     }
 
-    init(configuration: LinkConfigurationProtocol, log: Logger) {
+    init(configuration: LinkConfigurationProtocol) {
         self.configuration = configuration
-        self.log = log
     }
 
     func parseUrl(_ url: URL) -> DeepLink? {
         guard configuration.isURLSupported(url) else {
-            log.debug("[PDP deeplink] '\(url.absoluteString)' rejected: scheme/host not supported")
             return nil
         }
 
         guard let productMatch = url.path().wholeMatch(of: urlRegex) else {
-            log.debug("[PDP deeplink] path '\(url.path())' is not a /product/<slug> link (falls through to webView)")
             return nil
         }
         let slug = productMatch.output.1
         let navigationRoute = url.query().flatMap { extractRoute(from: $0) }
         let normalisedWebUrl = url.httpSecureUrl(using: configuration)
-        log.debug("[PDP deeplink] matched: slug='\(slug)'")
         return .init(
             type: .productDetail(
                 slug: slug,

--- a/Alfie/AlfieKit/Sources/DeepLink/Parsers/ProductDetailsDeepLinkParser.swift
+++ b/Alfie/AlfieKit/Sources/DeepLink/Parsers/ProductDetailsDeepLinkParser.swift
@@ -14,12 +14,13 @@ final class ProductDetailsDeepLinkParser: DeepLinkParserProtocol {
 
     // MARK: Regex Components
 
-    /// Captures the whole `/product/<slug>` path segment as the BFF handle. The slug is used as-is — the
-    /// BFF resolves a product by its slug, so there is nothing else to extract.
+    /// Captures the single `/product/<slug>` path segment as the BFF handle. The slug is used as-is — the
+    /// BFF resolves a product by its slug, so there is nothing else to extract. `/` is excluded so deeper
+    /// paths (e.g. `/product/<slug>/reviews`) are not mistaken for a PDP link and fall through to the web view.
     private let urlRegex = Regex {
         Constants.urlPrefixRegex
         Capture {
-            OneOrMore(.any)
+            OneOrMore(.anyNonNewline.subtracting(.anyOf("/")))
         } transform: {
             String($0)
         }

--- a/Alfie/AlfieKit/Sources/Home/Navigation/HomeFlowViewModel.swift
+++ b/Alfie/AlfieKit/Sources/Home/Navigation/HomeFlowViewModel.swift
@@ -152,7 +152,7 @@ public final class HomeFlowViewModel: HomeFlowViewModelProtocol {
                     switch productDetailsRoute {
                     case .productDetails(let configuration):
                         switch configuration {
-                        case .id(let configurationProductID):
+                        case .id(let configurationProductID), .deepLink(let configurationProductID):
                             productID = configurationProductID
                             product = nil
 

--- a/Alfie/AlfieKit/Sources/Model/Services/DeepLink/DeepLink.swift
+++ b/Alfie/AlfieKit/Sources/Model/Services/DeepLink/DeepLink.swift
@@ -16,7 +16,7 @@ public struct DeepLink {
 
         // Screens
         case productList(category: String, query: String?, urlParameters: [String: String]?)
-        case productDetail(id: String, description: String, route: String?, query: [String: String]?)
+        case productDetail(slug: String, route: String?, query: [String: String]?)
 
         public func configurationKey() -> ConfigurationKey? {
             // In case a link type depends on a specific feature toggle to be enabled, return the key here

--- a/Alfie/AlfieKit/Sources/ProductDetails/Models/ProductDetailsConfiguration.swift
+++ b/Alfie/AlfieKit/Sources/ProductDetails/Models/ProductDetailsConfiguration.swift
@@ -3,6 +3,8 @@ import Model
 
 public enum ProductDetailsConfiguration: Hashable {
     case id(_ id: String)
+    /// Deep-link entry: `handle` is the product slug taken straight from the URL and used as the BFF handle.
+    case deepLink(handle: String)
     case product(_ product: Product)
     case selectedProduct(_ selectedProduct: SelectedProduct)
 }

--- a/Alfie/AlfieKit/Sources/ProductDetails/UI/ProductDetailsViewModel.swift
+++ b/Alfie/AlfieKit/Sources/ProductDetails/UI/ProductDetailsViewModel.swift
@@ -90,9 +90,13 @@ public final class ProductDetailsViewModel: ProductDetailsViewModelProtocol {
         switch configuration {
         case .id(let productId):
             self.productId = productId
-            // TODO: ALFMOB-386 — deep-link entry only has the numeric id, not the BFF handle (slug).
-            // Using the id as the handle until the handle/slug source is confirmed.
             self.productHandle = productId
+            self.initialSelectedProduct = nil
+            self.baseProduct = nil
+
+        case .deepLink(let handle):
+            self.productId = handle
+            self.productHandle = handle
             self.initialSelectedProduct = nil
             self.baseProduct = nil
 

--- a/Alfie/AlfieKit/Sources/ProductListing/Navigation/ProductListingFlowViewModel.swift
+++ b/Alfie/AlfieKit/Sources/ProductListing/Navigation/ProductListingFlowViewModel.swift
@@ -151,7 +151,7 @@ public final class ProductListingFlowViewModel: ObservableObject, FlowViewModelP
                     switch productDetailsRoute {
                     case .productDetails(let configuration):
                         switch configuration {
-                        case .id(let configurationProductID):
+                        case .id(let configurationProductID), .deepLink(let configurationProductID):
                             productID = configurationProductID
                             product = nil
 

--- a/Alfie/AlfieKit/Tests/DeepLinkTests/Handlers/DeepLinkHandlerTests.swift
+++ b/Alfie/AlfieKit/Tests/DeepLinkTests/Handlers/DeepLinkHandlerTests.swift
@@ -250,15 +250,15 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
         sut.isReadyToHandleLinks = true
 
-        let productId = "123456"
+        let slug = "123456"
         let deepLink = DeepLink(
-            type: .productDetail(id: productId, description: "", route: nil, query: nil),
+            type: .productDetail(slug: slug, route: nil, query: nil),
             fullUrl: testUrl
         )
         sut.handleDeepLink(deepLink)
 
         wait(for: [expectation], timeout: .default)
-        XCTAssertEqual(receivedLinkType, .productDetail(id: productId, description: "", route: nil, query: nil))
+        XCTAssertEqual(receivedLinkType, .productDetail(slug: slug, route: nil, query: nil))
     }
 
     func test_handles_bag_links() {

--- a/Alfie/AlfieKit/Tests/DeepLinkTests/Parsers/ProductDetailsDeepLinkParserTests.swift
+++ b/Alfie/AlfieKit/Tests/DeepLinkTests/Parsers/ProductDetailsDeepLinkParserTests.swift
@@ -1,3 +1,4 @@
+import AlicerceLogging
 import Model
 import XCTest
 @testable import DeepLink
@@ -13,7 +14,7 @@ final class ProductDetailsDeepLinkParserTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
         linkConfig = .init()
-        sut = .init(configuration: linkConfig)
+        sut = .init(configuration: linkConfig, log: Log.DummyLogger())
     }
 
     override func tearDownWithError() throws {
@@ -44,9 +45,7 @@ final class ProductDetailsDeepLinkParserTests: XCTestCase {
         let testLinks = [
             "\(Self.httpUrl)/products",
             "\(Self.httpUrl)/products/polo-26146503?nav=885035/",
-            "\(Self.httpUrl)/product/polo-26146503-suffix-not-expected",
-            "\(Self.httpUrl)/product/polo-short-product-id-12345",
-            "\(Self.httpUrl)/product/polo-long-product-id-1234567",
+            "\(Self.httpUrl)/product/",
         ]
 
         try assertNoParse(testLinks)
@@ -55,24 +54,15 @@ final class ProductDetailsDeepLinkParserTests: XCTestCase {
 
     // MARK: - Product Links
 
-    func test_parses_product_links_with_id_only_as_pdp() throws {
+    func test_parses_product_links_with_numeric_slug_as_pdp() throws {
         let testLinks = [
             "\(Self.httpUrl)/product/26146503",
             "\(Self.httpUrl)/product/24449925?something=test",
             "\(Self.httpUrl)/product/25562382?#ins_sr=eyJwcm9kdWN0SWQiOiIyNTU2MjM4MiJ9",
         ]
-        try assertParse(testLinks[0],
-                        id: "26146503",
-                        description: "",
-                        route: nil)
-        try assertParse(testLinks[1],
-                        id: "24449925",
-                        description: "",
-                        route: nil)
-        try assertParse(testLinks[2],
-                        id: "25562382",
-                        description: "",
-                        route: nil)
+        try assertParse(testLinks[0], slug: "26146503", route: nil)
+        try assertParse(testLinks[1], slug: "24449925", route: nil)
+        try assertParse(testLinks[2], slug: "25562382", route: nil)
     }
 
     func test_ignores_casing_when_parsing_product_links() throws {
@@ -81,41 +71,23 @@ final class ProductDetailsDeepLinkParserTests: XCTestCase {
             "\(Self.httpUrl)/PRODUCT/24449925",
             "\(Self.httpUrl)/pRoDuCt/25562382",
         ]
-        try assertParse(testLinks[0],
-                        id: "26146503",
-                        description: "",
-                        route: nil)
-        try assertParse(testLinks[1],
-                        id: "24449925",
-                        description: "",
-                        route: nil)
-        try assertParse(testLinks[2],
-                        id: "25562382",
-                        description: "",
-                        route: nil)
+        try assertParse(testLinks[0], slug: "26146503", route: nil)
+        try assertParse(testLinks[1], slug: "24449925", route: nil)
+        try assertParse(testLinks[2], slug: "25562382", route: nil)
     }
 
-    func test_parses_product_links_with_id_and_route_only_as_pdp() throws {
+    func test_parses_product_links_with_numeric_slug_and_route_as_pdp() throws {
         let testLinks = [
             "\(Self.httpUrl)/product/26146503?nav=885035",
             "\(Self.httpUrl)/product/24449925?something=test&nav=885035",
             "\(Self.httpUrl)/product/25562382?nav=927986#ins_sr=eyJwcm9kdWN0SWQiOiIyNTU2MjM4MiJ9",
         ]
-        try assertParse(testLinks[0],
-                        id: "26146503",
-                        description: "",
-                        route: "885035")
-        try assertParse(testLinks[1],
-                        id: "24449925",
-                        description: "",
-                        route: "885035")
-        try assertParse(testLinks[2],
-                        id: "25562382",
-                        description: "",
-                        route: "927986")
+        try assertParse(testLinks[0], slug: "26146503", route: "885035")
+        try assertParse(testLinks[1], slug: "24449925", route: "885035")
+        try assertParse(testLinks[2], slug: "25562382", route: "927986")
     }
 
-    func test_parses_product_links_with_description_and_route_as_pdp() throws {
+    func test_parses_product_links_with_slug_and_route_as_pdp() throws {
         let testLinks = [
             "\(Self.httpUrl)/product/polo-ralph-lauren-ao-short-sleeve-t-shirt-26146503?nav=885035",
             "\(Self.httpUrl)/product/lanc%C3%B4me-absolue-the-serum-30ml-24449925?nav=927986",
@@ -124,39 +96,47 @@ final class ProductDetailsDeepLinkParserTests: XCTestCase {
         ]
 
         try assertParse(testLinks[0],
-                        id: "26146503",
-                        description: "polo-ralph-lauren-ao-short-sleeve-t-shirt-",
+                        slug: "polo-ralph-lauren-ao-short-sleeve-t-shirt-26146503",
                         route: "885035")
         try assertParse(testLinks[1],
-                        id: "24449925",
-                        description: "lanc%C3%B4me-absolue-the-serum-30ml-",
+                        slug: "lanc%C3%B4me-absolue-the-serum-30ml-24449925",
                         route: "927986")
         try assertParse(testLinks[2],
-                        id: "22859726",
-                        description: "lanc%C3%B4me-advanced-g%C3%A9nifique-youth-activating-concentrate-serum-115ml-",
+                        slug: "lanc%C3%B4me-advanced-g%C3%A9nifique-youth-activating-concentrate-serum-115ml-22859726",
                         route: "927986")
         try assertParse(testLinks[3],
-                        id: "25642827",
-                        description: "bally-bomber%7Cblouson-",
+                        slug: "bally-bomber%7Cblouson-25642827",
                         route: "881496")
+    }
+
+    func test_parses_bare_handle_links_as_pdp() throws {
+        // Real BFF slugs are bare handles with no trailing numeric id: the whole `/product/<slug>`
+        // segment is the slug, used as-is as the BFF handle.
+        try assertParse("\(Self.httpUrl)/product/t-shirt",
+                        slug: "t-shirt",
+                        route: nil)
+        try assertParse("\(Self.httpUrl)/product/la-mer-creme-de-la-mer-moisturizing-cream",
+                        slug: "la-mer-creme-de-la-mer-moisturizing-cream",
+                        route: nil)
+        try assertParse("\(Self.httpUrl)/product/polo-short-product-id-12345",
+                        slug: "polo-short-product-id-12345",
+                        route: nil)
     }
 
     // MARK: - Helpers
 
     private func assertParse(_ link: String,
-                             id expectedId: String,
-                             description expectedDescription: String,
+                             slug expectedSlug: String,
                              route expectedRoute: String?) throws {
         let testUrl = try XCTUnwrap(URL(string: link))
         let queryParameters = testUrl.queryParameters
         let result = sut.parseUrl(testUrl)
-        guard case .productDetail(let id, let description, let route, let query) = result?.type else {
+        guard case .productDetail(let slug, let route, let query) = result?.type else {
             XCTFail()
             return
         }
 
-        XCTAssertEqual(id, expectedId)
-        XCTAssertEqual(description, expectedDescription)
+        XCTAssertEqual(slug, expectedSlug)
         XCTAssertEqual(route, expectedRoute)
         XCTAssertEqual(query, queryParameters)
     }

--- a/Alfie/AlfieKit/Tests/DeepLinkTests/Parsers/ProductDetailsDeepLinkParserTests.swift
+++ b/Alfie/AlfieKit/Tests/DeepLinkTests/Parsers/ProductDetailsDeepLinkParserTests.swift
@@ -45,6 +45,8 @@ final class ProductDetailsDeepLinkParserTests: XCTestCase {
             "\(Self.httpUrl)/products",
             "\(Self.httpUrl)/products/polo-26146503?nav=885035/",
             "\(Self.httpUrl)/product/",
+            // A deeper path under /product/ is not a PDP link — the slug is a single path segment.
+            "\(Self.httpUrl)/product/t-shirt/reviews",
         ]
 
         try assertNoParse(testLinks)

--- a/Alfie/AlfieKit/Tests/DeepLinkTests/Parsers/ProductDetailsDeepLinkParserTests.swift
+++ b/Alfie/AlfieKit/Tests/DeepLinkTests/Parsers/ProductDetailsDeepLinkParserTests.swift
@@ -1,4 +1,3 @@
-import AlicerceLogging
 import Model
 import XCTest
 @testable import DeepLink
@@ -14,7 +13,7 @@ final class ProductDetailsDeepLinkParserTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
         linkConfig = .init()
-        sut = .init(configuration: linkConfig, log: Log.DummyLogger())
+        sut = .init(configuration: linkConfig)
     }
 
     override func tearDownWithError() throws {

--- a/Alfie/AlfieKit/Tests/ProductDetailsTests/ProductDetailsViewModelTests.swift
+++ b/Alfie/AlfieKit/Tests/ProductDetailsTests/ProductDetailsViewModelTests.swift
@@ -383,6 +383,20 @@ final class ProductDetailsViewModelTests: XCTestCase {
         wait(for: [expectation], timeout: .default)
     }
 
+    func test_deep_link_entry_fetches_using_slug_handle() {
+        initViewModel(configuration: .deepLink(handle: "nice-shirt-26146503"))
+
+        let expectation = expectation(description: "Wait for service call")
+        mockProductService.onGetProductCalled = { handle in
+            XCTAssertEqual(handle, "nice-shirt-26146503")
+            expectation.fulfill()
+            return .fixture()
+        }
+
+        sut.viewDidAppear()
+        wait(for: [expectation], timeout: .default)
+    }
+
     func test_product_is_not_fetched_when_view_appears_if_already_fetched() {
         let productId = "1"
         initViewModel(configuration: .id(productId))


### PR DESCRIPTION
## Ticket
[ALFMOB-386](https://mindera.atlassian.net/browse/ALFMOB-386)

## Summary
- Deep links to the PDP now resolve by the product **slug** taken straight from the `/product/<slug>` URL, instead of the old numeric id — the BFF's `productDetails(handle:)` resolves by slug, so id-based links always returned "not found".
- `ProductDetailsDeepLinkParser` captures the whole `/product/<slug>` segment as the BFF handle; both bare-handle (`/product/t-shirt`) and legacy id-suffixed (`/product/<slug>-26146503`) URLs are supported.
- Simplified the model end-to-end: `DeepLink.productDetail(slug:route:query:)`, `ProductDetailsConfiguration.deepLink(handle:)`, with routing passing the slug directly through to the PDP.
- Added a debug log in the parser so deep-link resolution is observable in the console.
- Updated parser, deep-link handler, and PDP ViewModel unit tests; added bare-handle parsing coverage.

## Screenshot

https://github.com/user-attachments/assets/c954dccf-56f6-43b5-93c3-cc1585fb8742


[ALFMOB-386]: https://mindera.atlassian.net/browse/ALFMOB-386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ