### PR TITLE
ALFMOB-267: Refactor typography components to use design tokens

### DIFF
--- a/Alfie/AlfieKit/Sources/SharedUI/DesignTokens/typography.styles.tokens.json
+++ b/Alfie/AlfieKit/Sources/SharedUI/DesignTokens/typography.styles.tokens.json
@@ -24,7 +24,7 @@
     "$value": {
       "fontFamily": "{body-medium-strikethrough-font-family}",
       "fontSize": "{body-medium-strikethrough-font-size}",
-      "fontWeight": "{body-medium-strikethrough-font-family}",
+      "fontWeight": "{body-medium-strikethrough-font-weight}",
       "letterSpacing": "{body-medium-strikethrough-kerning}",
       "lineHeight": "{body-medium-strikethrough-line-height}"
     }

--- a/Alfie/AlfieKit/Sources/SharedUI/GeneratedTokens/Typography+Generated.swift
+++ b/Alfie/AlfieKit/Sources/SharedUI/GeneratedTokens/Typography+Generated.swift
@@ -37,7 +37,7 @@ public enum Typography {
         )
         public static let mediumStrikethrough = TypographyStyle(
             fontFamily: Primitives.Typography.fontFamilyPrimaryIos,
-            fontWeight: Primitives.Typography.fontFamilyPrimaryIos,
+            fontWeight: Primitives.Typography.fontWeightRegular,
             fontSize: Primitives.Spacing.spacing16,
             lineHeight: Primitives.Spacing.spacing24,
             letterSpacing: Primitives.Typography.kerningNone

--- a/Alfie/AlfieKit/Sources/SharedUI/Theme/Typography/Helpers/FontNames.swift
+++ b/Alfie/AlfieKit/Sources/SharedUI/Theme/Typography/Helpers/FontNames.swift
@@ -14,14 +14,6 @@ public enum FontNames: String, CaseIterable {
             return "SF-Pro-Display-Medium"
         }
     }
-
-    public func withSize(_ size: CGFloat) -> UIFont {
-        guard let font = UIFont(name: rawValue, size: size) else {
-            assertionFailure("There is no font for this value \(rawValue)")
-            return UIFont()
-        }
-        return font
-    }
 }
 
 // MARK: - FontManager

--- a/Alfie/AlfieKit/Sources/SharedUI/Theme/Typography/Helpers/TypographyStyle+Font.swift
+++ b/Alfie/AlfieKit/Sources/SharedUI/Theme/Typography/Helpers/TypographyStyle+Font.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+import class UIKit.UIFont
+
+// MARK: - TypographyStyle → Font
+
+extension TypographyStyle {
+    /// UIKit font built from the token's family, weight and size.
+    public var uiFont: UIFont {
+        // SF Pro is the system typeface: `systemFont(ofSize:weight:)` resolves the numeric token
+        // weight against the installed system faces without needing a bundled font file. Any other
+        // (e.g. future brand) family is looked up by name — where the face itself carries the weight.
+        if fontFamily == Primitives.Typography.fontFamilyPrimaryIos {
+            return .systemFont(ofSize: fontSize, weight: uiFontWeight)
+        }
+        return UIFont(name: fontFamily, size: fontSize)
+            ?? .systemFont(ofSize: fontSize, weight: uiFontWeight)
+    }
+
+    /// SwiftUI font built from the token.
+    public var font: Font {
+        uiFont.font
+    }
+
+    /// Maps a numeric (CSS-style) token weight onto the nearest `UIFont.Weight` bucket.
+    private var uiFontWeight: UIFont.Weight {
+        switch fontWeight {
+        case ..<150: return .ultraLight
+        case ..<250: return .thin
+        case ..<350: return .light
+        case ..<450: return .regular
+        case ..<550: return .medium
+        case ..<650: return .semibold
+        case ..<750: return .bold
+        case ..<850: return .heavy
+        default: return .black
+        }
+    }
+}

--- a/Alfie/AlfieKit/Sources/SharedUI/Theme/Typography/Specifications/TypographyHeaderProtocol.swift
+++ b/Alfie/AlfieKit/Sources/SharedUI/Theme/Typography/Specifications/TypographyHeaderProtocol.swift
@@ -28,9 +28,9 @@ public protocol TypographyHeaderProtocol {
 // MARK: - TypographyHeader
 
 public final class TypographyHeader: TypographyHeaderProtocol {
-    public var h1: UIFont { FontNames.sfProMedium.withSize(36) }
-    public var h2: UIFont { FontNames.sfProMedium.withSize(24) }
-    public var h3: UIFont { FontNames.sfProMedium.withSize(20) }
+    public var h1: UIFont { Typography.Heading.large.uiFont }
+    public var h2: UIFont { Typography.Heading.medium.uiFont }
+    public var h3: UIFont { Typography.Heading.small.uiFont }
 
     public init() {}
 
@@ -61,7 +61,7 @@ public final class TypographyHeader: TypographyHeaderProtocol {
     }
 
     public func h3(_ res: LocalizedStringResource) -> AttributedString {
-        h2(String(localized: res))
+        h3(String(localized: res))
     }
 
     public func h3Underline(_ str: String) -> AttributedString {

--- a/Alfie/AlfieKit/Sources/SharedUI/Theme/Typography/Specifications/TypographyParagraphProtocol.swift
+++ b/Alfie/AlfieKit/Sources/SharedUI/Theme/Typography/Specifications/TypographyParagraphProtocol.swift
@@ -42,10 +42,10 @@ public protocol TypographyParagraphProtocol {
 // MARK: - TypographyParagraph
 
 public final class TypographyParagraph: TypographyParagraphProtocol {
-    public var normal: UIFont { FontNames.sfProMedium.withSize(16) }
-    public var normalItalic: UIFont { FontNames.sfProMedium.withSize(16) }
-    public var bold: UIFont { FontNames.sfProMedium.withSize(16) }
-    public var boldItalic: UIFont { FontNames.sfProMedium.withSize(16) }
+    public var normal: UIFont { Typography.Body.medium.uiFont }
+    public var normalItalic: UIFont { Typography.Body.medium.uiFont }
+    public var bold: UIFont { Typography.Body.medium.uiFont }
+    public var boldItalic: UIFont { Typography.Body.medium.uiFont }
 
     public init() {}
 

--- a/Alfie/AlfieKit/Sources/SharedUI/Theme/Typography/Specifications/TypographySmallProtocol.swift
+++ b/Alfie/AlfieKit/Sources/SharedUI/Theme/Typography/Specifications/TypographySmallProtocol.swift
@@ -38,10 +38,10 @@ public protocol TypographySmallProtocol {
 // MARK: - TypographySmall
 
 public class TypographySmall: TypographySmallProtocol {
-    public var normal: UIFont { FontNames.sfProMedium.withSize(14) }
-    public var normalItalic: UIFont { FontNames.sfProMedium.withSize(14) }
-    public var bold: UIFont { FontNames.sfProMedium.withSize(14) }
-    public var boldItalic: UIFont { FontNames.sfProMedium.withSize(14) }
+    public var normal: UIFont { Typography.Body.small.uiFont }
+    public var normalItalic: UIFont { Typography.Body.small.uiFont }
+    public var bold: UIFont { Typography.Body.small.uiFont }
+    public var boldItalic: UIFont { Typography.Body.small.uiFont }
 
     public init() {}
 

--- a/Alfie/AlfieKit/Sources/SharedUI/Theme/Typography/Specifications/TypographyTinyProtocol.swift
+++ b/Alfie/AlfieKit/Sources/SharedUI/Theme/Typography/Specifications/TypographyTinyProtocol.swift
@@ -29,10 +29,10 @@ public protocol TypographyTinyProtocol {
 // MARK: - TypographyTiny
 
 public class TypographyTiny: TypographyTinyProtocol {
-    public var normal: UIFont { FontNames.sfProMedium.withSize(12) }
-    public var normalItalic: UIFont { FontNames.sfProMedium.withSize(12) }
-    public var bold: UIFont { FontNames.sfProMedium.withSize(12) }
-    public var boldItalic: UIFont { FontNames.sfProMedium.withSize(12) }
+    public var normal: UIFont { Typography.Body.small.uiFont }
+    public var normalItalic: UIFont { Typography.Body.small.uiFont }
+    public var bold: UIFont { Typography.Body.small.uiFont }
+    public var boldItalic: UIFont { Typography.Body.small.uiFont }
 
     public init() {}
 

--- a/Alfie/AlfieKit/Tests/SharedUITests/StyleGuideTests.swift
+++ b/Alfie/AlfieKit/Tests/SharedUITests/StyleGuideTests.swift
@@ -2,11 +2,32 @@ import XCTest
 @testable import SharedUI
 
 final class StyleGuideTests: XCTestCase {
-    func testExample() throws {
-        // XCTest Documentation
-        // https://developer.apple.com/documentation/xctest
+    // MARK: - TypographyStyle → UIFont bridge
 
-        // Defining Test Cases and Test Methods
-        // https://developer.apple.com/documentation/xctest/defining_test_cases_and_test_methods
+    func testUIFontUsesTokenSize() {
+        XCTAssertEqual(Typography.Body.medium.uiFont.pointSize, Typography.Body.medium.fontSize)
+        XCTAssertEqual(Typography.Heading.large.uiFont.pointSize, Typography.Heading.large.fontSize)
+    }
+
+    func testRegularWeightTokenMapsToRegularSystemFont() {
+        // Body.medium is weight 400 → .regular
+        XCTAssertEqual(
+            Typography.Body.medium.uiFont,
+            .systemFont(ofSize: Typography.Body.medium.fontSize, weight: .regular)
+        )
+    }
+
+    func testMediumWeightTokenMapsToMediumSystemFont() {
+        // Heading.large is weight 500 → .medium
+        XCTAssertEqual(
+            Typography.Heading.large.uiFont,
+            .systemFont(ofSize: Typography.Heading.large.fontSize, weight: .medium)
+        )
+    }
+
+    func testSFProFamilyResolvesToSystemFont() {
+        // The primary iOS family is the system typeface, so the token font must equal a system font.
+        let font = Typography.Body.small.uiFont
+        XCTAssertEqual(font.familyName, UIFont.systemFont(ofSize: font.pointSize).familyName)
     }
 }

--- a/Docs/Plans/ALFMOB-267-typography-label-tokens/_status.md
+++ b/Docs/Plans/ALFMOB-267-typography-label-tokens/_status.md
@@ -21,6 +21,6 @@
 - [x] GATE: approval
 - [x] 5. Implement (ios-execute)
 - [x] 6. Commit
-- [ ] 7. PR
-- [ ] 8. Ticket transition
-- [ ] 9. Report
+- [x] 7. PR → https://github.com/Mindera/Alfie-iOS/pull/90
+- [~] 8. Ticket transition — skipped (Atlassian MCP disconnected; needs re-auth)
+- [x] 9. Report

--- a/Docs/Plans/ALFMOB-267-typography-label-tokens/_status.md
+++ b/Docs/Plans/ALFMOB-267-typography-label-tokens/_status.md
@@ -1,0 +1,26 @@
+# Status — ALFMOB-267
+
+**Title:** [iOS] Refactor Typography/Label components to use design tokens
+**Ticket:** https://mindera.atlassian.net/browse/ALFMOB-267 (Story)
+**Base:** claude/affectionate-hodgkin-b608a2 (carries fontWeight/fontFamily token typing; not on main)
+**Branch:** ALFMOB-267-typography-label-tokens
+
+## Acceptance Criteria
+- [ ] All text rendering uses token-generated typography
+- [ ] No hardcoded font sizes, weights, or family names in typography utilities
+- [ ] AttributedString builders produce correctly styled text
+- [ ] UIFont mappings reflect token values
+- [ ] All typography levels render correctly (h1, h2, h3, paragraph, small, tiny)
+
+## Phase checklist
+- [x] 1. Resolve input (ticket fetched)
+- [x] 2. Init (branch created off base)
+- [x] 3. Scout → scope.md
+- [x] 4. Plan → plan.md
+- [x] 4.5 Grill → hardened plan.md
+- [x] GATE: approval
+- [x] 5. Implement (ios-execute)
+- [x] 6. Commit
+- [ ] 7. PR
+- [ ] 8. Ticket transition
+- [ ] 9. Report

--- a/Docs/Plans/ALFMOB-267-typography-label-tokens/grill.md
+++ b/Docs/Plans/ALFMOB-267-typography-label-tokens/grill.md
@@ -1,0 +1,27 @@
+# Grill: Refactor Typography/Label components to use design tokens
+**Plan**: Docs/Plans/ALFMOB-267-typography-label-tokens/plan.md   **Ticket**: ALFMOB-267   **Date**: 2026-07-07   **Branch**: ALFMOB-267-typography-label-tokens
+
+## Decisions
+| # | Decision | Recommended | Chosen | Plan change |
+|---|---|---|---|---|
+| 1 | How specs adopt tokens given no 1:1 scale match | Faithful adoption | Faithful adoption | Decisions §1; accept visual changes, refresh snapshots, PR flags for design |
+| 2 | Apply token lineHeight/letterSpacing? | Font only this ticket | Font only | Decisions §2; metrics deferred to follow-up; Risk (double-subtraction) closed |
+| 3 | Unblock the token-source defect | Edit JSON now + raise upstream | Edit JSON now + raise upstream | Phase 0 confirmed; upstream Figma follow-up noted |
+| 4 | Where does `small` (14pt, no token) map? | Body.small (12) | Body.small (12) | Mapping table; small & tiny converge at 12/400 |
+| 5 | How to map normal/bold/italic variants (no bold/italic tokens) | Keep current behavior | Keep current behavior | Decisions §4; all variants → same base token, no synthesis |
+
+## Answered by the codebase (not asked)
+- Blocker root cause + fix location — `Tools/DesignTokenGen/.../Emitter.swift:111-116` emits faithfully; defect is `SharedUI/DesignTokens/typography.styles.tokens.json:27` (fontWeight ref → `-font-family`). Correct alias exists unused at `typography.alfie-theme.tokens.json:54`.
+- `Display.*` (brand "Libre Baskerville") out of scope — not bundled (`FontNames.swift:9` only has SF Pro) and no spec references it.
+- Provider API (`header/paragraph/small/tiny`) stays stable — ticket scopes "components", not the ~78 call sites.
+- SF Pro family → `UIFont.systemFont(ofSize:weight:)` (SF Pro is the system typeface) removes the "SF Pro Display Medium" hardcode without needing a bundled file.
+
+## Assumptions surfaced
+- The base branch (`claude/affectionate-hodgkin-b608a2`) does **not** currently compile — the generated typography file has a `String`→`Int` type error. Phase 0 is a hard prerequisite, not optional cleanup.
+- "Phase 1 token integration" (per the ticket) generated the token *values* but never wired the spec classes to them — the specs are still fully hardcoded. This ticket is that wiring.
+- Current italic/bold variants are visually identical to normal today (all `sfProMedium`); "keep current behavior" therefore introduces no variant-level visual change.
+
+## Still open (owner)
+- **Design**: sign-off on the accepted visual changes (h1 36→32; paragraph/small/tiny weight 500→400; small 14→12; small≈tiny convergence). Reviewed at PR.
+- **Design/Figma owner**: correct the `body-medium-strikethrough` fontWeight binding in the Figma token source so `pull-design-tokens.sh` doesn't reintroduce the defect.
+- **Follow-up ticket**: apply token lineHeight & letterSpacing in the AttributedString builders (deferred from this ticket).

--- a/Docs/Plans/ALFMOB-267-typography-label-tokens/phase-0-unblock-tokens.md
+++ b/Docs/Plans/ALFMOB-267-typography-label-tokens/phase-0-unblock-tokens.md
@@ -1,0 +1,28 @@
+## Phase 0: Unblock build (fix token source + regenerate)
+### Goal
+Make the SharedUI module compile again by correcting the source-JSON defect that produced an
+invalid `Typography+Generated.swift` (a `String` assigned to the `Int fontWeight` field).
+
+### Acceptance criteria
+- [ ] `typography.styles.tokens.json` `body-medium-strikethrough.fontWeight` references
+      `{body-medium-strikethrough-font-weight}` (not `-font-family`).
+- [ ] Regenerated `Typography+Generated.swift` line for `Body.mediumStrikethrough` reads
+      `fontWeight: Primitives.Typography.fontWeightRegular`.
+- [ ] Build compiles (`verify.sh` gets past the SharedUI compile error).
+
+### Steps
+1. **Fix source token ref** (file: `Alfie/AlfieKit/Sources/SharedUI/DesignTokens/typography.styles.tokens.json:27`, size: XS)
+   — change `"fontWeight": "{body-medium-strikethrough-font-family}"` →
+   `"fontWeight": "{body-medium-strikethrough-font-weight}"`. The target alias already exists
+   (`typography.alfie-theme.tokens.json:54`, value `{typography-font-weight-regular}` = 400).
+2. **Regenerate tokens** (size: XS) — run `./Alfie/scripts/generate-design-tokens.sh`; commit the
+   regenerated `GeneratedTokens/Typography+Generated.swift`. Do **not** hand-edit the generated file.
+3. **Raise upstream** (size: XS, non-code) — note in the PR / ticket that the Figma token source has
+   the same binding defect so the fix isn't lost on the next `pull-design-tokens.sh`.
+
+### Checkpoint
+- [ ] `./Alfie/scripts/verify.sh` passes (or at minimum SharedUI compiles).
+- [ ] Only the one composite changed; `git diff` on generated file shows exactly the one field flip.
+
+### Depends on
+none

--- a/Docs/Plans/ALFMOB-267-typography-label-tokens/phase-1-font-bridge.md
+++ b/Docs/Plans/ALFMOB-267-typography-label-tokens/phase-1-font-bridge.md
@@ -1,0 +1,29 @@
+## Phase 1: TypographyStyle → UIFont bridge
+### Goal
+Provide a single, tested place that turns a generated `TypographyStyle` into a `UIFont` (and SwiftUI
+`Font`), so specs can read token values instead of hardcoded `FontNames.sfProMedium.withSize(N)`.
+
+### Acceptance criteria
+- [ ] `TypographyStyle` → `UIFont` maps `fontWeight` 400→`.regular`, 500→`.medium` and uses
+      `fontSize` from the token.
+- [ ] SF Pro family (`fontFamilyPrimaryIos` = "SF Pro") resolves via `UIFont.systemFont(ofSize:weight:)`.
+- [ ] A convenience `var font: Font` (SwiftUI) is available (mirrors existing `UIFont.font`).
+- [ ] Unit tests cover the weight mapping and size passthrough.
+
+### Steps
+1. **Add bridge** (file: `Alfie/AlfieKit/Sources/SharedUI/Theme/Typography/Helpers/TypographyStyle+Font.swift`, **new**, size: S)
+   — `extension TypographyStyle { var uiFont: UIFont { … } }`: map `fontWeight` Int →
+   `UIFont.Weight` (400 `.regular`, 500 `.medium`, sensible default otherwise); for the SF Pro family
+   return `UIFont.systemFont(ofSize: fontSize, weight: …)`. Keep a named-font fallback
+   (`UIFont(name:size:)`) for any non-system family (guards future brand-font use) but do **not**
+   hardcode a family string. Add `var font: Font { .init(uiFont) }`.
+2. **Unit tests** (file: `Alfie/AlfieKit/Tests/SharedUITests/StyleGuideTests.swift`, size: S)
+   — assert `Typography.Body.medium.uiFont.pointSize == 16`, weight mapping for a 400 and a 500 token,
+   and that a known token yields the expected system font.
+
+### Checkpoint
+- [ ] `./Alfie/scripts/verify.sh` passes (new tests green).
+- [ ] No spec behaviour changed yet (bridge is additive).
+
+### Depends on
+Phase 0

--- a/Docs/Plans/ALFMOB-267-typography-label-tokens/phase-2-migrate-specs.md
+++ b/Docs/Plans/ALFMOB-267-typography-label-tokens/phase-2-migrate-specs.md
@@ -1,0 +1,44 @@
+## Phase 2: Migrate spec classes to tokens
+### Goal
+Re-point `TypographyHeader/Paragraph/Small/Tiny` at the generated tokens via the Phase-1 bridge,
+removing hardcoded sizes/weights/family, while keeping the `header/paragraph/small/tiny` API stable.
+
+### Acceptance criteria
+- [ ] Every `UIFont` var in the four spec classes derives from a `Typography.*` token (per the
+      approved mapping) — zero `FontNames.sfProMedium.withSize(N)` literals remain in the specs.
+- [ ] AttributedString builders (String + `LocalizedStringResource`) still return styled text for all
+      variants (normal/italic/bold/boldItalic/underline/strike).
+- [ ] Pre-existing bug fixed: `TypographyHeaderProtocol.swift:64` `h3(_ res:)` calls `h3(...)`, not `h2`.
+- [ ] `TypographyDemoView` still renders all levels; snapshot baselines refreshed.
+
+### Mapping (decided — see plan.md Decisions)
+`h1→Heading.large` · `h2→Heading.medium` · `h3→Heading.small` · `paragraph.*→Body.medium` ·
+`small.*→Body.small` · `tiny.*→Body.small`. Font metrics only (family/weight/size). All variants of
+a scale read the same base token (no synthesized bold/italic).
+
+### Steps
+1. **Header** (file: `.../Specifications/TypographyHeaderProtocol.swift:31-33,64`, size: S)
+   — `h1→Typography.Heading.large.uiFont`, `h2→Heading.medium`, `h3→Heading.small`; fix the
+   `h3(_ res:)`→`h2` typo (line 64).
+2. **Paragraph** (file: `.../Specifications/TypographyParagraphProtocol.swift:45-48`, size: S)
+   — all of `normal/normalItalic/bold/boldItalic` → `Typography.Body.medium.uiFont`.
+3. **Small** (file: `.../Specifications/TypographySmallProtocol.swift:41-44`, size: S)
+   — all variants → `Typography.Body.small.uiFont` (14→12).
+4. **Tiny** (file: `.../Specifications/TypographyTinyProtocol.swift:32-35`, size: S)
+   — all variants → `Typography.Body.small.uiFont`.
+5. **FontNames cleanup** (file: `.../Helpers/FontNames.swift`, size: S)
+   — after migration, grep for remaining `FontNames.sfProMedium` uses; if none, remove the
+   `withSize` size-hardcode path. Keep `FontManager` registration only if a bundled font is still
+   referenced elsewhere.
+6. ~~Refresh snapshots~~ **N/A** — the snapshot test files are not in the `AlfieTests` target
+   membership (`ProductDetailsViewSnapshotTests.swift:8` "TODO: Re-add Target Membership once
+   Snapshot tests are checked for working properly"), so they don't compile/run in verify or CI.
+   No baseline refresh needed; re-enabling them is out of scope.
+
+### Checkpoint
+- [ ] `./Alfie/scripts/verify.sh` passes.
+- [ ] Manual: `TypographyDemoView` shows each level at the token size/weight.
+- [ ] Grep: no hardcoded font size/weight/family in `Theme/Typography/`.
+
+### Depends on
+Phase 1 (+ the mapping decisions from the grill/approval gate)

--- a/Docs/Plans/ALFMOB-267-typography-label-tokens/plan.md
+++ b/Docs/Plans/ALFMOB-267-typography-label-tokens/plan.md
@@ -1,0 +1,109 @@
+---
+title: Refactor Typography/Label components to use design tokens
+ticket: ALFMOB-267
+status: completed
+complexity: MEDIUM
+mode: auto
+blockedBy: []
+blocks: []
+created: 2026-07-07
+---
+
+## Overview
+Route the four typography spec classes (`TypographyHeader/Paragraph/Small/Tiny`) through the
+generated `Typography.*` design tokens instead of hardcoded `FontNames.sfProMedium.withSize(N)`
+literals, keeping the `header/paragraph/small/tiny` provider API stable so the ~78 call sites are
+untouched. First unblock the build: the base branch shipped a broken generated token file caused by
+a defect in the source token JSON.
+
+## Acceptance Criteria (from ticket)
+- [ ] All text rendering (header/paragraph/small/tiny) uses token-generated typography values.
+- [ ] No hardcoded font sizes, weights, or family names in the typography utilities.
+- [ ] AttributedString builders still produce correctly styled text (String + LocalizedStringResource).
+- [ ] UIFont mappings reflect token values.
+- [ ] All typography levels render correctly (h1/h2/h3, paragraph, small, tiny variants).
+
+## Approach
+The generated `TypographyStyle` exposes `fontFamily:String`, `fontWeight:Int`, `fontSize`,
+`lineHeight`, `letterSpacing`. Add a **non-generated** `TypographyStyle → UIFont` bridge in SharedUI
+(family+weight+size → `UIFont`), then re-point each spec's `UIFont` vars at the mapped token. The SF
+Pro family maps to `UIFont.systemFont(ofSize:weight:)` (SF Pro *is* the system typeface), which
+removes the `"SF Pro Display Medium"` string hardcode. `Display.*` tokens use the brand family
+`"Libre Baskerville"` which is **not bundled** and is **not used** by these four specs → out of scope.
+
+The token set does **not** cover the current scale 1:1 (no 36, no 14) — see Open Questions; the
+scale→token mapping is the central decision and is resolved at the grill/approval gate.
+
+## Phases (vertical slices, dependency order)
+- **Phase 0 — Unblock build** (`phase-0-unblock-tokens.md`): fix the source-JSON defect + regenerate.
+- **Phase 1 — TypographyStyle→UIFont bridge** (`phase-1-font-bridge.md`): the family+weight→UIFont
+  resolver + SwiftUI `Font`, with unit tests. No behaviour change to specs yet.
+- **Phase 2 — Migrate specs to tokens** (`phase-2-migrate-specs.md`): re-point Header/Paragraph/Small/
+  Tiny at tokens via the bridge per the agreed mapping; remove hardcoded sizes/family; fix the
+  pre-existing `h3(_ res:)`→`h2` bug; refresh snapshot baselines; update `TypographyDemoView` if needed.
+
+## File Changes (Summary Table)
+| File | Module | Type | Change | Owner |
+|---|---|---|---|---|
+| `SharedUI/DesignTokens/typography.styles.tokens.json` | SharedUI | edit | line 27 `-font-family` → `-font-weight` | - |
+| `SharedUI/GeneratedTokens/Typography+Generated.swift` | SharedUI | regen | via `generate-design-tokens.sh` (do not hand-edit) | - |
+| `SharedUI/Theme/Typography/Helpers/TypographyStyle+Font.swift` | SharedUI | **new** | `TypographyStyle`→`UIFont`/`Font` bridge | - |
+| `SharedUI/Theme/Typography/Specifications/TypographyHeaderProtocol.swift` | SharedUI | edit | vars→tokens; fix `h3(_ res:)` bug | - |
+| `SharedUI/Theme/Typography/Specifications/TypographyParagraphProtocol.swift` | SharedUI | edit | vars→tokens | - |
+| `SharedUI/Theme/Typography/Specifications/TypographySmallProtocol.swift` | SharedUI | edit | vars→tokens | - |
+| `SharedUI/Theme/Typography/Specifications/TypographyTinyProtocol.swift` | SharedUI | edit | vars→tokens | - |
+| `SharedUI/Theme/Typography/Helpers/FontNames.swift` | SharedUI | edit | drop `sfProMedium` size hardcode if unused post-migration | - |
+| `AlfieKit/Tests/SharedUITests/StyleGuideTests.swift` | SharedUITests | edit | add token-value assertions (file is empty today) | - |
+| `AlfieTests/Snapshots/*ViewSnapshotTests.swift` | AlfieTests | regen | refresh baselines if rendering changes | - |
+
+## Feature Flag
+n/a — pure internal refactor of the shared typography layer. No user-facing toggle; not a
+`high_rigor_domain`.
+
+## Testing Strategy
+- **Unit** (`StyleGuideTests`, currently empty): assert each spec's `UIFont.pointSize`/weight equals
+  the mapped token's `fontSize`/`fontWeight`; assert the `TypographyStyle→UIFont` bridge maps
+  400→`.regular`, 500→`.medium`, and SF Pro → system font.
+- **Snapshot**: existing page-level snapshots (`ProductDetails/Brands/Categories/Search/Shop`) act as
+  the visual regression guard; re-record baselines once the mapping is signed off.
+- **Manual**: `TypographyDemoView` in the Debug menu renders every level for eyeball verification.
+- Gate: `./Alfie/scripts/verify.sh` green after each phase.
+
+## Risks & Mitigations
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Token JSON is a Figma export (`pull-design-tokens.sh`); the line-27 fix is clobbered on next pull | Med | Fix locally to unblock now **and** raise the defect against the Figma token source (out-of-repo follow-up) |
+| Mapping changes rendered text (h1 36→32, paragraph weight 500→400, small 14→?) | High | Explicit mapping table signed off at grill/approval; refresh snapshots; keep provider API stable |
+| `small`=14 and `h1`=36 have no matching token | High | Open Question — resolve at grill (map to nearest / add token upstream / keep size override) |
+| Applying token `lineHeight`/`letterSpacing` via `.build()` double-counts (existing `Text.build` subtracts pointSize) | Med | Default: keep builders font-only this ticket; treat line-height/kerning application as a separate decision (Open Q) |
+| Removing bundled `SF Pro Display Medium` font/registration breaks other consumers | Low | Only drop `FontNames.sfProMedium` if grep confirms zero remaining uses post-migration; else leave registration intact |
+
+## Out of Scope
+- `Display.*` (brand "Libre Baskerville") tokens — font not bundled, not used by these specs.
+- Renaming the provider API to token role names (Body/Heading/Label/Link) — would touch ~78 call sites.
+- Hardcoded `.withSize(N)` in consumers (`ThemedToolbarTitle/Button` 18, `PriceComponentView` 12/14/16,
+  `SortByView` 18) — call-site overrides, not typography utilities; separate cleanup.
+- `NSAttributedString.fromHtml` line-height heuristic (`fontSize + 8`) — HTML rendering, separate concern.
+
+## Decisions (from grill — see grill.md)
+1. **Faithful adoption** — specs read token values; visual changes are accepted (tokens are the new
+   source of truth). Snapshots refreshed; PR flags the changes for design sign-off.
+2. **Font only this ticket** — route family/weight/size through tokens; **defer** token
+   line-height & letter-spacing to a follow-up (avoids the `Text.build()` double-subtraction risk).
+3. **Edit JSON now + raise upstream** — correct the exported source JSON to unblock, and file the
+   same fix against the Figma token source.
+4. **Variants keep current behavior** — all variants of a scale (normal/italic/bold/boldItalic/
+   underline/strike) read the **same** base token; no synthesized bold/italic (none exist in tokens).
+   Matches today's rendering (variants are already visually identical).
+
+### Final scale→token mapping (SF Pro family only; font metrics only)
+| Current spec (size/weight) | Token | Token size/weight | Net change |
+|---|---|---|---|
+| `header.h1` (36/500) | `Typography.Heading.large` | 32 / 500 | size 36→32 |
+| `header.h2` (24/500) | `Typography.Heading.medium` | 24 / 500 | none (kerning deferred) |
+| `header.h3` (20/500) | `Typography.Heading.small` | 20 / 500 | none (kerning deferred) |
+| `paragraph.*` (16/500) | `Typography.Body.medium` | 16 / 400 | weight 500→400 |
+| `small.*` (14/500) | `Typography.Body.small` | 12 / 400 | size 14→12, weight 500→400 |
+| `tiny.*` (12/500) | `Typography.Body.small` | 12 / 400 | weight 500→400 |
+
+Note: `small` & `tiny` converge at 12/400 — an accepted consequence flagged for design.

--- a/Docs/Plans/ALFMOB-267-typography-label-tokens/scope.md
+++ b/Docs/Plans/ALFMOB-267-typography-label-tokens/scope.md
@@ -1,0 +1,44 @@
+# Scout Report: Typography rendering system — ALFMOB-267
+
+**Branch:** ALFMOB-267-typography-label-tokens   **Agents:** 2
+
+## Core typography system (all under `Alfie/AlfieKit/Sources/SharedUI/Theme/Typography/`)
+- `TypographyProvider.swift:5-34` — `TypographyProviderProtocol` (`header`/`paragraph`/`small`/`tiny`) + concrete provider instantiating the 4 spec classes.
+- `Specifications/TypographyHeaderProtocol.swift:31-33` — **HARDCODED** `h1=withSize(36)`, `h2=24`, `h3=20`; plus AttributedString builders (:37-76).
+- `Specifications/TypographyParagraphProtocol.swift:45-48` — **HARDCODED** normal/normalItalic/bold/boldItalic = 16; builders :52-134.
+- `Specifications/TypographySmallProtocol.swift:41-44` — **HARDCODED** = 14; builders :48-130.
+- `Specifications/TypographyTinyProtocol.swift:32-35` — **HARDCODED** = 12; builders :39-88.
+- `Helpers/FontNames.swift:9` — **HARDCODED** single family `sfProMedium = "SF Pro Display Medium"`; `withSize(_:)` :18-24 builds `UIFont(name:size:)`, falls back to empty `UIFont()`.
+- `Helpers/Font+Extensions.swift:8-41` — `AttributedString.build()` combines font/lineHeight/letterSpacing/strike/underline (`kern` :28-29, `lineSpacing` :37-39). `:67-123` `NSAttributedString.fromHtml()` with **hardcoded** lineHeight offset (`lineHeight ?? fontSize + 8.0` :87).
+
+## Generated token API (READ-ONLY — do not edit `GeneratedTokens/`)
+- `GeneratedTokens/Typography+Generated.swift` — `struct TypographyStyle { fontFamily: String; fontWeight: Int; fontSize: CGFloat; lineHeight: CGFloat; letterSpacing: CGFloat }`.
+  Categories: `Typography.Body` (large/medium/mediumStrikethrough/small), `Typography.Display` (large/medium/small), `Typography.Heading` (large/medium/small/xSmall), `Typography.Label` (small/smallBold), `Typography.Link` (medium/small).
+- `GeneratedTokens/Primitives+Generated.swift:63-88` — families: `fontFamilyBrand="Libre Baskerville"`, `fontFamilyPrimaryIos="SF Pro"`; weights: `fontWeightRegular=400`, `fontWeightMedium=500`; kerning none/tight/spacious; lineHeights aliased to Spacing.
+
+## Consumers with hardcoded font sizes (app target + SharedUI)
+- `SharedUI/.../ThemedToolbarTitle.swift:54` — `paragraph.normal.withSize(18)`.
+- `SharedUI/.../ThemedToolbarButton.swift:72` (const :19 = 18.0).
+- `SharedUI/.../PriceComponentView.swift:55-94,158,209` — 12/14/16 variants via `.withSize(textSize)`.
+- `SharedUI/.../SortByView.swift:79` — `paragraph.normal.withSize(18)`.
+- `Theme/HtmlText/ThemedHtmlText.swift:14-19` — NSAttributedString HTML parse, no token routing.
+
+## ThemeProvider wiring
+- `Theme/DesignSystem.swift:12,27,29,36,42` — `font: TypographyProviderProtocol` (default `TypographyProvider()`, swappable); `setupAppearance()` uses `font.header.h3`.
+
+## Tests
+- `AlfieKit/Tests/SharedUITests/StyleGuideTests.swift` — **empty placeholder** (no typography assertions).
+- Snapshot tests (page-level, not typography-isolated): `AlfieTests/Snapshots/{ProductDetails,Brands,Categories,Search,Shop}ViewSnapshotTests.swift`; helper `AlfieTests/Helpers/View+Snapshots.swift`.
+- `DebugMenu/UI/Demo/Typography/TypographyDemoView.swift` — renders every scale (visual verification).
+
+## ⚠️ BLOCKER inherited from base branch (must fix to build)
+- `GeneratedTokens/Typography+Generated.swift:40` — `Body.mediumStrikethrough` has `fontWeight: Primitives.Typography.fontFamilyPrimaryIos` (a `String`) assigned to the `Int fontWeight` field → **hard compile error in SharedUI**, blocks the whole build.
+- **Source JSON is correct**: `typography.alfie-theme.tokens.json:54` `body-medium-strikethrough-font-weight` → `{typography-font-weight-regular}` (=400). The fault is in the **generator** `Tools/DesignTokenGen` (mis-resolves the strikethrough variant's font-weight to the family primitive). Generated files are do-not-edit → fix must be in the generator + `./Alfie/scripts/generate-design-tokens.sh` regenerate.
+- Prerequisite phase for ALFMOB-267 (Phase 1 landed this broken file on `claude/affectionate-hodgkin-b608a2`).
+
+## Key open questions / risks for planning
+1. **Mapping is not 1:1.** Current scales (h1 36 / h2 24 / h3 20 / paragraph 16 / small 14 / tiny 12) don't map cleanly onto token categories (Heading large/medium/small/xSmall, Body large=18/…, Display, Label, Link). Token sizes differ from current hardcoded sizes (e.g. Body.large=18 vs paragraph.normal=16) → **migration will change rendered output**. Need an explicit scale→token map.
+2. **UIFont construction from tokens.** `TypographyStyle` gives `fontFamily:String` + `fontWeight:Int`; current path is `UIFont(name:"SF Pro Display Medium")`. Need a family+weight→UIFont resolver (system font vs named). SF Pro is a system font; "SF Pro Display Medium" is a specific PostScript name.
+3. **lineHeight & letterSpacing** exist in tokens but the spec `UIFont` vars don't carry them; they're applied only in `AttributedString.build()`. Decide whether specs expose full `TypographyStyle` or stay UIFont-only.
+4. **Consumers using `.withSize(N)`** (toolbar 18, price 12/14/16) have no matching scale — decide keep-as-override vs map to a token.
+5. **No unit tests** currently guard typography → add tests asserting specs read token values.


### PR DESCRIPTION
## ALFMOB-267 — Refactor Typography components to use design tokens

Routes the typography spec classes (`TypographyHeader/Paragraph/Small/Tiny`) through the generated `Typography.*` design tokens instead of hardcoded `FontNames.sfProMedium.withSize(N)` literals. The `header/paragraph/small/tiny` provider API is unchanged, so the ~78 call sites are untouched.

> **Base:** targets `claude/affectionate-hodgkin-b608a2` (not `main`) — that branch carries the fontWeight/fontFamily token typing this work depends on. Stacked PR.

### What changed
- **Build unblock (inherited defect):** `typography.styles.tokens.json` `body-medium-strikethrough` bound `fontWeight` to the *font-family* ref, so the generated `TypographyStyle.fontWeight` (`Int`) received a `String` → SharedUI didn't compile. Fixed the source ref and regenerated. **The Figma token source has the same defect — needs correcting upstream so `pull-design-tokens.sh` doesn't reintroduce it.**
- **`TypographyStyle → UIFont` bridge** (`TypographyStyle+Font.swift`): family+weight+size → `UIFont`; SF Pro resolves via `systemFont(ofSize:weight:)`, removing the `"SF Pro Display Medium"` hardcode. Unit-tested.
- **Specs migrated to tokens** per the agreed mapping; removed the now-orphaned `FontNames.withSize`; fixed a pre-existing bug where `header.h3(_ res:)` rendered as **h2**.

### Scale → token mapping (font metrics only)
| Spec | Token | Net change |
|---|---|---|
| h1 | `Heading.large` | 36 → 32 |
| h2 / h3 | `Heading.medium` / `Heading.small` | unchanged |
| paragraph.* | `Body.medium` | weight 500 → 400 |
| small.* | `Body.small` | 14 → 12, weight 500 → 400 |
| tiny.* | `Body.small` | weight 500 → 400 |

### ⚠️ Accepted visual changes (need design sign-off)
h1 shrinks 36→32; paragraph/small/tiny drop to weight 400; small shrinks 14→12 (small ≈ tiny at 12pt). This is faithful token adoption — tokens are the new source of truth.

### Decisions & scope
Font metrics only; token **line-height / letter-spacing deferred** to a follow-up (avoids the existing `Text.build()` double-subtraction). Out of scope: `Display.*`/brand font (not bundled, unused), call-site `.withSize(N)` overrides, and removing the now-dormant `FontNames`/`FontManager` bundled-font registration (touches app startup + asset catalog). Full decision log in `Docs/Plans/ALFMOB-267-typography-label-tokens/`.

### Testing
`./Alfie/scripts/verify.sh --skip-integration` → ✅ build + full unit suite + 4 new `StyleGuideTests`. Integration skipped (no BFF impact). Snapshot tests are disabled project-wide (not in `AlfieTests` target membership), so no baselines needed refreshing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)