### PR TITLE
fix: align iOS menu query with renamed BFF 'menu' field

### DIFF
--- a/Alfie/AlfieKit/Sources/BFFGraph/API/Operations/Queries/MainMenuQuery.graphql.swift
+++ b/Alfie/AlfieKit/Sources/BFFGraph/API/Operations/Queries/MainMenuQuery.graphql.swift
@@ -8,7 +8,7 @@ public extension BFFGraphAPI {
     public static let operationName: String = "MainMenuQuery"
     public static let operationDocument: ApolloAPI.OperationDocument = .init(
       definition: .init(
-        #"query MainMenuQuery($handle: String!) { mainMenu(handle: $handle) { __typename handle title items { __typename id title url items { __typename id title url items { __typename id title url } } } } }"#
+        #"query MainMenuQuery($handle: String!) { menu(handle: $handle) { __typename handle title items { __typename id title url items { __typename id title url items { __typename id title url } } } } }"#
       ))
 
     public var handle: String
@@ -25,15 +25,15 @@ public extension BFFGraphAPI {
 
       public static var __parentType: any ApolloAPI.ParentType { BFFGraphAPI.Objects.Query }
       public static var __selections: [ApolloAPI.Selection] { [
-        .field("mainMenu", MainMenu.self, arguments: ["handle": .variable("handle")]),
+        .field("menu", Menu.self, arguments: ["handle": .variable("handle")]),
       ] }
 
-      public var mainMenu: MainMenu { __data["mainMenu"] }
+      public var menu: Menu { __data["menu"] }
 
-      /// MainMenu
+      /// Menu
       ///
       /// Parent Type: `Menu`
-      public struct MainMenu: BFFGraphAPI.SelectionSet {
+      public struct Menu: BFFGraphAPI.SelectionSet {
         public let __data: DataDict
         public init(_dataDict: DataDict) { __data = _dataDict }
 
@@ -49,7 +49,7 @@ public extension BFFGraphAPI {
         public var title: String? { __data["title"] }
         public var items: [Item] { __data["items"] }
 
-        /// MainMenu.Item
+        /// Menu.Item
         ///
         /// Parent Type: `MenuItem`
         public struct Item: BFFGraphAPI.SelectionSet {
@@ -70,7 +70,7 @@ public extension BFFGraphAPI {
           public var url: String? { __data["url"] }
           public var items: [Item?]? { __data["items"] }
 
-          /// MainMenu.Item.Item
+          /// Menu.Item.Item
           ///
           /// Parent Type: `MenuItem`
           public struct Item: BFFGraphAPI.SelectionSet {
@@ -91,7 +91,7 @@ public extension BFFGraphAPI {
             public var url: String? { __data["url"] }
             public var items: [Item?]? { __data["items"] }
 
-            /// MainMenu.Item.Item.Item
+            /// Menu.Item.Item.Item
             ///
             /// Parent Type: `MenuItem`
             public struct Item: BFFGraphAPI.SelectionSet {

--- a/Alfie/AlfieKit/Sources/BFFGraph/CodeGen/Queries/Navigation/MainMenu.graphql
+++ b/Alfie/AlfieKit/Sources/BFFGraph/CodeGen/Queries/Navigation/MainMenu.graphql
@@ -1,7 +1,7 @@
 query MainMenuQuery(
     $handle: String!
 ) {
-    mainMenu(handle: $handle) {
+    menu(handle: $handle) {
         handle
         title
         items {

--- a/Alfie/AlfieKit/Sources/BFFGraph/CodeGen/Schema/schema.graphqls
+++ b/Alfie/AlfieKit/Sources/BFFGraph/CodeGen/Schema/schema.graphqls
@@ -212,7 +212,7 @@ type ProductVariant {
 type Query {
   cart(cartId: String!): Cart!
   cartCheckoutUrl(cartId: String!): String!
-  mainMenu(handle: String! = "main-menu"): Menu!
+  menu(handle: String! = "main-menu"): Menu!
   productDetails(handle: String!, productMetafields: [MetafieldIdentifierInput!], variantMetafields: [MetafieldIdentifierInput!]): OmniProduct
   productList(after: String, collectionHandle: String!, filters: ProductFilterInput, limit: Int! = 25, sort: ProductSortEnum! = NEWEST): ProductListResponse!
   searchProducts(after: String, filters: ProductFilterInput, limit: Int! = 10, searchTerm: String!, sort: ProductSortEnum! = NEWEST): ProductListResponse!

--- a/Alfie/AlfieKit/Sources/BFFGraph/Mocks/Query+Mock.graphql.swift
+++ b/Alfie/AlfieKit/Sources/BFFGraph/Mocks/Query+Mock.graphql.swift
@@ -10,7 +10,7 @@ class Query: MockObject {
   typealias MockValueCollectionType = Array<Mock<Query>>
 
   struct MockFields {
-    @Field<Menu>("mainMenu") public var mainMenu
+    @Field<Menu>("menu") public var menu
     @Field<OmniProduct>("productDetails") public var productDetails
     @Field<ProductListResponse>("productList") public var productList
     @Field<ProductListResponse>("searchProducts") public var searchProducts
@@ -19,13 +19,13 @@ class Query: MockObject {
 
 extension Mock where O == Query {
   convenience init(
-    mainMenu: Mock<Menu>? = nil,
+    menu: Mock<Menu>? = nil,
     productDetails: Mock<OmniProduct>? = nil,
     productList: Mock<ProductListResponse>? = nil,
     searchProducts: Mock<ProductListResponse>? = nil
   ) {
     self.init()
-    _setEntity(mainMenu, for: \.mainMenu)
+    _setEntity(menu, for: \.menu)
     _setEntity(productDetails, for: \.productDetails)
     _setEntity(productList, for: \.productList)
     _setEntity(searchProducts, for: \.searchProducts)

--- a/Alfie/AlfieKit/Sources/Core/Services/BFFService/BFFClientService.swift
+++ b/Alfie/AlfieKit/Sources/Core/Services/BFFService/BFFClientService.swift
@@ -54,7 +54,7 @@ public final class BFFClientService: BFFClientServiceProtocol {
 
     public func getHeaderNav(handle: NavigationHandle) async throws -> [NavigationItem] {
         let menuHandle = handle.bffMenuHandle
-        log.info("mainMenu → handle=\(menuHandle)")
+        log.info("menu → handle=\(menuHandle)")
 
         do {
             // The menu is never served from cache: the normalized cache has no TTL, so a cached menu
@@ -62,17 +62,17 @@ public final class BFFClientService: BFFClientServiceProtocol {
             let items = try await executeFetch(
                 BFFGraphAPI.MainMenuQuery(handle: menuHandle),
                 cachePolicy: .fetchIgnoringCacheData
-            ).mainMenu.convertToNavigationItems()
+            ).menu.convertToNavigationItems()
             if items.isEmpty {
                 // Menu returned but nothing was actionable — no recognizable collection links.
                 // Surfaces an otherwise-silent empty Shop screen.
-                log.error("mainMenu ← 0 actionable categories (no recognizable collection links)")
+                log.error("menu ← 0 actionable categories (no recognizable collection links)")
             } else {
-                log.info("mainMenu ← items=\(items.count)")
+                log.info("menu ← items=\(items.count)")
             }
             return items
         } catch {
-            log.error("mainMenu failed: \(error)")
+            log.error("menu failed: \(error)")
             throw error
         }
     }

--- a/Alfie/AlfieKit/Sources/Core/Services/BFFService/Converters/MainMenu+Converter.swift
+++ b/Alfie/AlfieKit/Sources/Core/Services/BFFService/Converters/MainMenu+Converter.swift
@@ -2,7 +2,7 @@ import BFFGraph
 import Foundation
 import Model
 
-extension BFFGraphAPI.MainMenuQuery.Data.MainMenu {
+extension BFFGraphAPI.MainMenuQuery.Data.Menu {
     public func convertToNavigationItems() -> [NavigationItem] {
         items.compactMap { $0.convertToNavigationItem() }
     }
@@ -10,7 +10,7 @@ extension BFFGraphAPI.MainMenuQuery.Data.MainMenu {
 
 // Apollo generates a distinct type per nesting level, so each level gets a thin adapter over the
 // shared `makeNavigationItem` builder.
-extension BFFGraphAPI.MainMenuQuery.Data.MainMenu.Item {
+extension BFFGraphAPI.MainMenuQuery.Data.Menu.Item {
     fileprivate func convertToNavigationItem() -> NavigationItem? {
         makeNavigationItem(
             id: id,
@@ -21,7 +21,7 @@ extension BFFGraphAPI.MainMenuQuery.Data.MainMenu.Item {
     }
 }
 
-extension BFFGraphAPI.MainMenuQuery.Data.MainMenu.Item.Item {
+extension BFFGraphAPI.MainMenuQuery.Data.Menu.Item.Item {
     fileprivate func convertToNavigationItem() -> NavigationItem? {
         makeNavigationItem(
             id: id,
@@ -32,7 +32,7 @@ extension BFFGraphAPI.MainMenuQuery.Data.MainMenu.Item.Item {
     }
 }
 
-extension BFFGraphAPI.MainMenuQuery.Data.MainMenu.Item.Item.Item {
+extension BFFGraphAPI.MainMenuQuery.Data.Menu.Item.Item.Item {
     // The query intentionally caps nesting at 3 levels (Shopify's menu depth limit), so the
     // deepest level has no children to convert.
     fileprivate func convertToNavigationItem() -> NavigationItem? {

--- a/Alfie/AlfieKit/Tests/BFFGraphTests/MainMenuConverterTests.swift
+++ b/Alfie/AlfieKit/Tests/BFFGraphTests/MainMenuConverterTests.swift
@@ -207,7 +207,7 @@ final class MainMenuConverterTests: XCTestCase {
 // MARK: - Test factory
 
 private extension MainMenuConverterTests {
-    func makeMenu(items: [Mock<MenuItem>]) -> BFFGraphAPI.MainMenuQuery.Data.MainMenu {
-        BFFGraphAPI.MainMenuQuery.Data.MainMenu.from(Mock<Menu>(handle: "main-menu", items: items, title: "Main"))
+    func makeMenu(items: [Mock<MenuItem>]) -> BFFGraphAPI.MainMenuQuery.Data.Menu {
+        BFFGraphAPI.MainMenuQuery.Data.Menu.from(Mock<Menu>(handle: "main-menu", items: items, title: "Main"))
     }
 }


### PR DESCRIPTION
## Summary
- BFF ticket **AF-95** renamed the GraphQL query field `mainMenu` → `menu` (arg `handle` and the `Menu` type shape are unchanged). The iOS app still queried `mainMenu`, so the Shop category menu fails against the latest BFF (`Cannot query field "mainMenu" on type "Query"`).
- Update `MainMenuQuery` to request `menu(handle:)` (operation name kept `MainMenuQuery`), re-sync the committed schema, and regenerate the Apollo API/mocks.
- Update consumers: `BFFClientService` accessor `.menu`, `MainMenu+Converter` types `…Data.Menu`, and the converter test.

## Testing
- `./Alfie/scripts/verify.sh --skip-integration` — build + unit tests pass.
- Ran the app in the simulator against the latest `main` BFF: Shop categories load (Women/Men/Kids/Beauty), drill-down works (Women → Bags/Clothes/Shoes/Sports), and a leaf category opens its PLP with real products.

## Notes
- Scope kept **menu-only**; the committed schema has other drift (e.g. a `weight` field) that a full `sync-bff-schema.sh` would pull in — recommended as a separate pass.
- No Jira ticket for the iOS side yet; references BFF **AF-95**.

## Screenshot